### PR TITLE
modify Acknowledgement.Data

### DIFF
--- a/contracts/core/TxAtomicSimple.sol
+++ b/contracts/core/TxAtomicSimple.sol
@@ -50,7 +50,7 @@ abstract contract TxAtomicSimple is IBCKeeper, PacketHandler, ContractRegistry {
         HeaderField.Data[] memory fields;
         return Acknowledgement.encode(
             Acknowledgement.Data({
-                is_success: ack.status == PacketAcknowledgementCall.CommitStatus.COMMIT_STATUS_OK,
+                is_success: true,
                 result: PacketData.encode(
                     PacketData.Data({
                         header: Header.Data({

--- a/pkg/testing/cross_test.go
+++ b/pkg/testing/cross_test.go
@@ -123,7 +123,7 @@ func (suite *CrossTestSuite) TestPBSerialization() {
 		expectedAckData := packets.NewPacketAcknowledgementData(nil, simpletypes.NewPacketAcknowledgementCall(simpletypes.COMMIT_STATUS_FAILED))
 		expectedAckDataBz, err := proto.Marshal(&expectedAckData)
 		suite.Require().NoError(err)
-		expectedAck := crosstypes.NewAcknowledgement(false, expectedAckDataBz)
+		expectedAck := crosstypes.NewAcknowledgement(true, expectedAckDataBz)
 		suite.Require().Equal(ack, expectedAck.Acknowledgement())
 	}
 }


### PR DESCRIPTION
Currently, cross requires that ack.IsSuccess() is true.
https://github.com/datachainlab/cross/blob/master/x/core/module.go#L324

For reference, in ibc-go, Success() only checks the type of Response.
https://github.com/cosmos/ibc-go/blob/db6f316cb044aec21636c2e83f7926ba6c2edfe4/modules/core/04-channel/types/acknowledgement.go#L52