### PR TITLE
feat: implement Authenticator abstract contract with signTx

### DIFF
--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -24,7 +24,6 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
         bytes32 txIdHash = sha256(msg_.txID);
 
         bool completed = sign(txIdHash, accounts);
-
         if (completed) {
             runTxIfCompleted(txIdHash);
         }

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import {IAuthenticator} from "./IAuthenticator.sol";
+import {TxAuthManagerBase} from "./TxAuthManagerBase.sol";
+import {TxManagerBase} from "./TxManagerBase.sol";
+
+import {
+    AuthType,
+    MsgSignTx,
+    MsgSignTxResponse,
+    MsgExtSignTx,
+    MsgExtSignTxResponse,
+    QueryTxAuthStateRequest,
+    QueryTxAuthStateResponse,
+    Account
+} from "../proto/cross/core/auth/Auth.sol";
+import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
+
+abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase {
+    function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
+        Account.Data[] memory accounts = _buildLocalAccounts(msg_.signers);
+
+        bytes32 txIdHash = sha256(msg_.txID);
+
+        bool completed = sign(txIdHash, accounts);
+
+        if (completed) {
+            runTxIfCompleted(txIdHash);
+        }
+
+        emit TxSigned(msg.sender, txIdHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+
+        return MsgSignTxResponse.Data({tx_auth_completed: completed, log: ""});
+    }
+
+    function extSignTx(
+        MsgExtSignTx.Data calldata /*msg_*/
+    )
+        external
+        override
+        returns (MsgExtSignTxResponse.Data memory)
+    {
+        revert IAuthenticator.ExtSignTxNotImplemented();
+    }
+
+    function txAuthState(
+        QueryTxAuthStateRequest.Data calldata /*req_*/
+    )
+        external
+        view
+        override
+        returns (QueryTxAuthStateResponse.Data memory resp)
+    {
+        revert IAuthenticator.TxAuthStateNotImplemented();
+    }
+
+    function _buildLocalAccounts(bytes[] calldata signerIDs) internal pure returns (Account.Data[] memory) {
+        AuthType.Data memory localAuthType = AuthType.Data({
+            mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: GoogleProtobufAny.Data({type_url: "", value: ""})
+        });
+
+        Account.Data[] memory accounts = new Account.Data[](signerIDs.length);
+        for (uint256 i = 0; i < signerIDs.length; ++i) {
+            accounts[i] = Account.Data({id: signerIDs[i], auth_type: localAuthType});
+        }
+        return accounts;
+    }
+}

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -21,14 +21,14 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
     function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
         Account.Data[] memory accounts = _buildLocalAccounts(msg_.signers);
 
-        bytes32 txIdHash = sha256(msg_.txID);
+        bytes32 txIDHash = sha256(msg_.txID);
 
-        bool completed = sign(txIdHash, accounts);
+        bool completed = sign(txIDHash, accounts);
         if (completed) {
-            runTxIfCompleted(txIdHash);
+            runTxIfCompleted(txIDHash);
         }
 
-        emit TxSigned(msg.sender, txIdHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+        emit TxSigned(msg.sender, txIDHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
 
         return MsgSignTxResponse.Data({tx_auth_completed: completed, log: ""});
     }

--- a/src/core/CrossModule.sol
+++ b/src/core/CrossModule.sol
@@ -14,6 +14,7 @@ import "./PacketHandler.sol";
 import "./IBCKeeper.sol";
 
 import {Initiator} from "./Initiator.sol";
+import {Authenticator} from "./Authenticator.sol";
 import {TxAuthManager} from "./TxAuthManager.sol";
 import {TxManager} from "./TxManager.sol";
 import {TxRunner} from "./TxRunner.sol";
@@ -24,6 +25,7 @@ abstract contract CrossModule is
     IBCKeeper,
     PacketHandler,
     Initiator,
+    Authenticator,
     TxAuthManager,
     TxManager,
     TxRunner

--- a/src/core/IAuthenticator.sol
+++ b/src/core/IAuthenticator.sol
@@ -12,9 +12,8 @@ import {
 } from "../proto/cross/core/auth/Auth.sol";
 
 interface IAuthenticator {
-    error AuthStateAlreadyInitialized(bytes32 txID);
-    error IDNotFound(bytes32 txID);
-    error AuthAlreadyCompleted(bytes32 txID);
+    error ExtSignTxNotImplemented();
+    error TxAuthStateNotImplemented();
 
     event TxSigned(address indexed signer, bytes32 indexed txID, AuthType.AuthMode method);
 

--- a/src/proto/cross/core/tx/Tx.sol
+++ b/src/proto/cross/core/tx/Tx.sol
@@ -613,11 +613,12 @@ library ResolvedContractTransaction {
      * @param counters The counters for repeated fields
      * @return The number of bytes decoded
      */
-    function _read_unpacked_repeated_call_results(uint256 p, bytes memory bs, Data memory r, uint256[6] memory counters)
-        internal
-        pure
-        returns (uint256)
-    {
+    function _read_unpacked_repeated_call_results(
+        uint256 p,
+        bytes memory bs,
+        Data memory r,
+        uint256[6] memory counters
+    ) internal pure returns (uint256) {
         /**
          * if `r` is NULL, then only counting the number of fields.
          */

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// solhint-disable one-contract-per-file, func-name-mixedcase, var-name-mixedcase, gas-small-strings
+pragma solidity ^0.8.20;
+
+import "forge-std/src/Test.sol";
+import "../src/core/Authenticator.sol";
+import {TxManagerBase} from "../src/core/TxManagerBase.sol";
+import {TxAuthManagerBase} from "../src/core/TxAuthManagerBase.sol";
+
+import {MsgInitiateTx} from "../src/proto/cross/core/initiator/Initiator.sol";
+import {IAuthenticator} from "../src/core/IAuthenticator.sol";
+import {
+    Account as AuthAccount,
+    AuthType,
+    TxAuthState,
+    MsgSignTx,
+    MsgSignTxResponse,
+    MsgExtSignTx,
+    QueryTxAuthStateRequest
+} from "../src/proto/cross/core/auth/Auth.sol";
+import {IbcCoreClientV1Height} from "../src/proto/ibc/core/client/v1/client.sol";
+
+contract MockTxManager is TxManagerBase {
+    bytes32 public lastRunTxId;
+    uint256 public runTxCount;
+
+    function createTx(
+        bytes32,
+        /*txId*/
+        MsgInitiateTx.Data calldata /*src*/
+    )
+        internal
+        virtual
+        override
+    {}
+
+    function runTxIfCompleted(bytes32 txId) internal virtual override {
+        lastRunTxId = txId;
+        ++runTxCount;
+    }
+
+    function isTxRecorded(
+        bytes32 /*txId*/
+    )
+        internal
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return false;
+    }
+}
+
+contract MockTxAuthManager is TxAuthManagerBase {
+    mapping(bytes32 => bool) public completed;
+    bool private _signReturns = false;
+
+    function initAuthState(
+        bytes32,
+        /*txId*/
+        Account.Data[] memory /*signers*/
+    )
+        internal
+        virtual
+        override
+    {}
+
+    function isCompletedAuth(
+        bytes32 /*txId*/
+    )
+        internal
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return false;
+    }
+
+    function sign(
+        bytes32 txId,
+        Account.Data[] memory /*signers*/
+    )
+        internal
+        virtual
+        override
+        returns (bool)
+    {
+        if (_signReturns) {
+            completed[txId] = true;
+        }
+        return _signReturns;
+    }
+    function getAuthState(bytes32) internal view virtual override returns (TxAuthState.Data memory) {}
+
+    function setSignReturns(bool returnsValue) public {
+        _signReturns = returnsValue;
+    }
+}
+
+contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager {
+    function exposed_buildLocalAccounts(bytes[] calldata signerIDs) public pure returns (AuthAccount.Data[] memory) {
+        return _buildLocalAccounts(signerIDs);
+    }
+}
+
+contract AuthenticatorTest is Test {
+    AuthenticatorHarness private harness;
+    MsgSignTx.Data private baseMsg;
+    bytes32 private txIdHash;
+    bytes private signerABytes = bytes("signerA");
+    bytes private signerBBytes = bytes("signerB");
+
+    event TxSigned(address indexed signer, bytes32 indexed txID, AuthType.AuthMode method);
+
+    function setUp() public {
+        harness = new AuthenticatorHarness();
+
+        bytes[] memory signers = new bytes[](1);
+        signers[0] = signerABytes;
+
+        baseMsg = MsgSignTx.Data({
+            txID: bytes("test-tx-id"),
+            signers: signers,
+            timeout_height: IbcCoreClientV1Height.Data(0, 0),
+            timeout_timestamp: 0
+        });
+
+        txIdHash = sha256(baseMsg.txID);
+    }
+
+    function test_signTx_SucceedsAsPending() public {
+        harness.setSignReturns(false);
+
+        MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
+        assertFalse(resp.tx_auth_completed, "response should indicate not completed");
+        assertEq(resp.log, "", "log should be empty");
+        assertFalse(harness.completed(txIdHash), "Mock: auth should not be completed");
+        assertEq(harness.runTxCount(), 0, "Mock: runTxIfCompleted should not be called");
+    }
+
+    function test_signTx_SucceedsAsCompletedAndEmitsEvent() public {
+        harness.setSignReturns(true);
+
+        vm.expectEmit(true, true, false, true, address(harness));
+        emit TxSigned(address(this), txIdHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+
+        MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
+
+        assertTrue(resp.tx_auth_completed, "response should indicate completed");
+        assertEq(resp.log, "", "log should be empty");
+        assertTrue(harness.completed(txIdHash), "Mock: auth should be completed");
+        assertEq(harness.runTxCount(), 1, "Mock: runTxIfCompleted should be called once");
+        assertEq(harness.lastRunTxId(), txIdHash, "Mock: runTxIfCompleted called with correct txId");
+    }
+
+    function test_extSignTx_RevertsNotImplemented() public {
+        MsgExtSignTx.Data memory msg_;
+        msg_.txID = bytes("ext-tx");
+        msg_.signers = new AuthAccount.Data[](0);
+
+        vm.expectRevert(IAuthenticator.ExtSignTxNotImplemented.selector);
+        harness.extSignTx(msg_);
+    }
+
+    function test_txAuthState_RevertsNotImplemented() public {
+        QueryTxAuthStateRequest.Data memory req;
+        req.txID = bytes("query-tx");
+
+        vm.expectRevert(IAuthenticator.TxAuthStateNotImplemented.selector);
+        harness.txAuthState(req);
+    }
+
+    function test_buildLocalAccounts_BuildsCorrectly() public {
+        bytes[] memory signerIDs = new bytes[](2);
+        signerIDs[0] = signerABytes;
+        signerIDs[1] = signerBBytes;
+
+        AuthAccount.Data[] memory accounts = harness.exposed_buildLocalAccounts(signerIDs);
+
+        assertEq(accounts.length, 2, "Array length mismatch");
+
+        assertEq(accounts[0].id, signerABytes, "Signer A ID mismatch");
+        assertEq(
+            uint256(accounts[0].auth_type.mode),
+            uint256(AuthType.AuthMode.AUTH_MODE_LOCAL),
+            "Signer A auth type mismatch"
+        );
+        assertEq(accounts[0].auth_type.option.type_url, "", "Signer A option type_url should be empty");
+        assertEq(accounts[0].auth_type.option.value, "", "Signer A option value should be empty");
+
+        assertEq(accounts[1].id, signerBBytes, "Signer B ID mismatch");
+        assertEq(
+            uint256(accounts[1].auth_type.mode),
+            uint256(AuthType.AuthMode.AUTH_MODE_LOCAL),
+            "Signer B auth type mismatch"
+        );
+        assertEq(accounts[1].auth_type.option.type_url, "", "Signer B option type_url should be empty");
+        assertEq(accounts[1].auth_type.option.value, "", "Signer B option value should be empty");
+    }
+}

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -21,12 +21,12 @@ import {
 import {IbcCoreClientV1Height} from "../src/proto/ibc/core/client/v1/client.sol";
 
 contract MockTxManager is TxManagerBase {
-    bytes32 public lastRunTxId;
+    bytes32 public lastRunTxID;
     uint256 public runTxCount;
 
     function createTx(
         bytes32,
-        /*txId*/
+        /*txID*/
         MsgInitiateTx.Data calldata /*src*/
     )
         internal
@@ -34,13 +34,13 @@ contract MockTxManager is TxManagerBase {
         override
     {}
 
-    function runTxIfCompleted(bytes32 txId) internal virtual override {
-        lastRunTxId = txId;
+    function runTxIfCompleted(bytes32 txID) internal virtual override {
+        lastRunTxID = txID;
         ++runTxCount;
     }
 
     function isTxRecorded(
-        bytes32 /*txId*/
+        bytes32 /*txID*/
     )
         internal
         view
@@ -58,7 +58,7 @@ contract MockTxAuthManager is TxAuthManagerBase {
 
     function initAuthState(
         bytes32,
-        /*txId*/
+        /*txID*/
         Account.Data[] memory /*signers*/
     )
         internal
@@ -67,7 +67,7 @@ contract MockTxAuthManager is TxAuthManagerBase {
     {}
 
     function isCompletedAuth(
-        bytes32 /*txId*/
+        bytes32 /*txID*/
     )
         internal
         view
@@ -79,7 +79,7 @@ contract MockTxAuthManager is TxAuthManagerBase {
     }
 
     function sign(
-        bytes32 txId,
+        bytes32 txID,
         Account.Data[] memory /*signers*/
     )
         internal
@@ -88,7 +88,7 @@ contract MockTxAuthManager is TxAuthManagerBase {
         returns (bool)
     {
         if (_signReturns) {
-            completed[txId] = true;
+            completed[txID] = true;
         }
         return _signReturns;
     }
@@ -108,7 +108,7 @@ contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager
 contract AuthenticatorTest is Test {
     AuthenticatorHarness private harness;
     MsgSignTx.Data private baseMsg;
-    bytes32 private txIdHash;
+    bytes32 private txIDHash;
     bytes private signerABytes = bytes("signerA");
     bytes private signerBBytes = bytes("signerB");
 
@@ -127,7 +127,7 @@ contract AuthenticatorTest is Test {
             timeout_timestamp: 0
         });
 
-        txIdHash = sha256(baseMsg.txID);
+        txIDHash = sha256(baseMsg.txID);
     }
 
     function test_signTx_SucceedsAsPending() public {
@@ -136,7 +136,7 @@ contract AuthenticatorTest is Test {
         MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
         assertFalse(resp.tx_auth_completed, "response should indicate not completed");
         assertEq(resp.log, "", "log should be empty");
-        assertFalse(harness.completed(txIdHash), "Mock: auth should not be completed");
+        assertFalse(harness.completed(txIDHash), "Mock: auth should not be completed");
         assertEq(harness.runTxCount(), 0, "Mock: runTxIfCompleted should not be called");
     }
 
@@ -144,15 +144,15 @@ contract AuthenticatorTest is Test {
         harness.setSignReturns(true);
 
         vm.expectEmit(true, true, false, true, address(harness));
-        emit TxSigned(address(this), txIdHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+        emit TxSigned(address(this), txIDHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
 
         MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
 
         assertTrue(resp.tx_auth_completed, "response should indicate completed");
         assertEq(resp.log, "", "log should be empty");
-        assertTrue(harness.completed(txIdHash), "Mock: auth should be completed");
+        assertTrue(harness.completed(txIDHash), "Mock: auth should be completed");
         assertEq(harness.runTxCount(), 1, "Mock: runTxIfCompleted should be called once");
-        assertEq(harness.lastRunTxId(), txIdHash, "Mock: runTxIfCompleted called with correct txId");
+        assertEq(harness.lastRunTxID(), txIDHash, "Mock: runTxIfCompleted called with correct txID");
     }
 
     function test_extSignTx_RevertsNotImplemented() public {


### PR DESCRIPTION
- Implemented `Authenticator.sol` and `signTx()`.
- Implemented unit tests for `signTx` and its helper functions.

```mermaid
graph TD
    subgraph " "
        direction LR
        CrossModule[(CrossModule)]
    end

    subgraph "Implementation abstract"
        direction TB
        Initiator[Initiator]
        Authenticator[Authenticator]
        TxAuthManager[TxAuthManager]
        TxManager[TxManager]
        TxRunner[TxRunner]
    end

    subgraph "Base Contracts & Interfaces"
        direction TB
        IInitiator{{IInitiator}}
        IAuthenticator{{IAuthenticator}}
        TxAuthManagerBase((TxAuthManagerBase))
        TxManagerBase((TxManagerBase))
        TxRunnerBase((TxRunnerBase))
    end

    subgraph "Storage (ERC7201)"
        direction TB
        CrossStore[CrossStore]
    end

    CrossModule -- inherits --> Initiator
    CrossModule -- inherits --> Authenticator
    CrossModule -- inherits --> TxAuthManager
    CrossModule -- inherits --> TxManager
    CrossModule -- inherits --> TxRunner

    Initiator -- implements --> IInitiator
    Initiator -- inherits & uses --> TxAuthManagerBase
    Initiator -- inherits & uses --> TxManagerBase

    TxAuthManager -- implements --> TxAuthManagerBase
    TxAuthManager -- uses storage --> CrossStore

    TxManager -- implements --> TxManagerBase
    TxManager -- inherits & uses --> TxRunnerBase
    TxManager -- uses storage --> CrossStore

    TxRunner -- implements --> TxRunnerBase
    
    Authenticator -- implements --> IAuthenticator
    Authenticator -- inherits & uses --> TxAuthManagerBase
    Authenticator -- inherits & uses --> TxManagerBase
    
    classDef interface fill:#e6f7ff,stroke:#0056b3,stroke-width:2px
    class IInitiator,IAuthenticator interface
    
    classDef base fill:#f0f0f0,stroke:#333,stroke-width:2px
    class TxAuthManagerBase,TxManagerBase,TxRunnerBase base
    
    classDef storage fill:#fffbe6,stroke:#d4a017,stroke-width:2px
    class CrossStore storage
```

```mermaid
graph TD
    %% =========================
    %% High-level architecture
    %% =========================
    subgraph "Deployed App Contract"
        direction TB
        CrossModule[(CrossModule)]
        style CrossModule stroke-width:2px

        subgraph "Abstract Impl (in CrossModule)"
            direction LR
            Initiator[Initiator]
            Authenticator[Authenticator]
            TxRunner[TxRunner]
        end

        subgraph "Shared Storage (ERC-7201 layout in callers)"
            direction TB
            CrossStore[(CrossStore)]
        end

        CrossModule -- inherits --> Initiator
        CrossModule -- inherits --> Authenticator
        CrossModule -- inherits --> TxRunner
        CrossModule --- CrossStore
    end

    %% ============ Facets / Delegates ============
    subgraph "Delegatecall Targets (Stateless Logic Contracts)"
        direction TB
        AuthFacet[[TxAuthManagerDelegate]]
        TxFacet[[TxManagerDelegate]]

        class AuthFacet,TxFacet facet
    end

    %% ============ Interfaces ============
    subgraph "Interfaces"
        direction TB
        ITxAuthManager{{ITxAuthManager}}
        ITxManager{{ITxManager}}
        class ITxAuthManager,ITxManager interface
    end

    %% ============ Wiring / Calls ============
    Initiator -- "«delegatecall» initAuthState/sign/getAuthState" --> AuthFacet
    Initiator -- "«delegatecall» createTx/isTxRecorded/runIfCompleted" --> TxFacet

    Authenticator -- "«delegatecall» initAuthState/sign/getAuthState" --> AuthFacet
    Authenticator -- "«delegatecall» createTx/isTxRecorded/runIfCompleted" --> TxFacet

    AuthFacet -. implements .-> ITxAuthManager
    TxFacet -. implements .-> ITxManager

    %% Delegates operate on caller storage via ERC-7201 slots
    AuthFacet -- "reads/writes via delegatecall" --> CrossStore
    TxFacet -- "reads/writes via delegatecall" --> CrossStore

    %% ============ Upgradability / Address slots ============
    subgraph "Facet Address Registry (in CrossModule storage)"
        direction TB
        AuthFacetAddr[(authFacetAddress)]
        TxFacetAddr[(txFacetAddress)]
    end
    CrossModule --- AuthFacetAddr
    CrossModule --- TxFacetAddr

    Admin[Admin/Owner/Role] -- "setAuthFacet()/setTxFacet()" --> CrossModule

    %% ============ Execution Path example ============
    subgraph "Tx Flow (example)"
        direction LR
        User[EOA/Relayer] -->|initiateTx()| Initiator
        Initiator -->|"derive txID, gather signers"| Initiator
        Initiator -- "«delegatecall» initAuthState(signers)" --> AuthFacet
        Initiator -- "«delegatecall» createTx(txID,msg)" --> TxFacet
        Initiator -->|"sign() → «delegatecall»"| AuthFacet
        AuthFacet -->|"remaining=0 ?"| Initiator
        Initiator -->|"if completed → «delegatecall» runIfCompleted(txID)"| TxFacet
        TxFacet -->|"calls _runTx via TxRunner in CrossModule"| TxRunner
    end

    %% ============ Styling ============
    classDef facet fill:#eef9f0,stroke:#2b8a3e,stroke-width:2px
    classDef interface fill:#e6f7ff,stroke:#0056b3,stroke-width:2px

```