### PR TITLE
feat: implement Authenticator abstract contract with signTx 

### DIFF
--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import {IAuthenticator} from "./IAuthenticator.sol";
+import {TxAuthManagerBase} from "./TxAuthManagerBase.sol";
+import {TxManagerBase} from "./TxManagerBase.sol";
+import {ICrossError} from "./ICrossError.sol";
+
+import {
+    AuthType,
+    MsgSignTx,
+    MsgSignTxResponse,
+    MsgExtSignTx,
+    MsgExtSignTxResponse,
+    QueryTxAuthStateRequest,
+    QueryTxAuthStateResponse,
+    Account
+} from "../proto/cross/core/auth/Auth.sol";
+import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
+
+abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, ICrossError {
+    function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
+        Account.Data[] memory accounts = _buildLocalAccounts(msg_.signers);
+
+        bytes32 txIDHash = sha256(msg_.txID);
+
+        bool completed = _sign(txIDHash, accounts);
+        if (completed) {
+            _runTxIfCompleted(txIDHash);
+        }
+
+        emit TxSigned(msg.sender, txIDHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+
+        return MsgSignTxResponse.Data({tx_auth_completed: completed, log: ""});
+    }
+
+    function extSignTx(
+        MsgExtSignTx.Data calldata /*msg_*/
+    )
+        external
+        override
+        returns (MsgExtSignTxResponse.Data memory)
+    {
+        revert ExtSignTxNotImplemented();
+    }
+
+    function txAuthState(
+        QueryTxAuthStateRequest.Data calldata /*req_*/
+    )
+        external
+        view
+        override
+        returns (QueryTxAuthStateResponse.Data memory resp)
+    {
+        revert TxAuthStateNotImplemented();
+    }
+
+    function _buildLocalAccounts(bytes[] calldata signerIDs) internal pure returns (Account.Data[] memory) {
+        AuthType.Data memory localAuthType = AuthType.Data({
+            mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: GoogleProtobufAny.Data({type_url: "", value: ""})
+        });
+
+        Account.Data[] memory accounts = new Account.Data[](signerIDs.length);
+        for (uint256 i = 0; i < signerIDs.length; ++i) {
+            accounts[i] = Account.Data({id: signerIDs[i], auth_type: localAuthType});
+        }
+        return accounts;
+    }
+}

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -20,6 +20,15 @@ import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/pr
 
 abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, ICrossError {
     function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
+        if (msg_.signers.length != 1) {
+            revert InvalidSignersLength();
+        }
+
+        bytes memory expectedSignerId = abi.encodePacked(msg.sender);
+        if (keccak256(msg_.signers[0]) != keccak256(expectedSignerId)) {
+            revert SignerMustEqualSender();
+        }
+
         Account.Data[] memory accounts = _buildLocalAccounts(msg_.signers);
 
         bytes32 txIDHash = sha256(msg_.txID);

--- a/src/core/CrossModule.sol
+++ b/src/core/CrossModule.sol
@@ -14,6 +14,7 @@ import "./PacketHandler.sol";
 import "./IBCKeeper.sol";
 
 import {Initiator} from "./Initiator.sol";
+import {Authenticator} from "./Authenticator.sol";
 import {DelegatedLogicHandler} from "./DelegatedLogicHandler.sol";
 import {CrossStore} from "./CrossStore.sol";
 
@@ -24,6 +25,7 @@ abstract contract CrossModule is
     PacketHandler,
     CrossStore,
     Initiator,
+    Authenticator,
     DelegatedLogicHandler
 {
     bytes32 public constant IBC_ROLE = keccak256("IBC_ROLE");

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -9,6 +9,8 @@ interface ICrossError {
     error TxIDAlreadyExists(bytes32 txIDHash);
     error AuthStateAlreadyInitialized(bytes32 txID);
     error IDNotFound(bytes32 txID);
+    error InvalidSignersLength();
+    error SignerMustEqualSender();
     error AuthAlreadyCompleted(bytes32 txID);
     error TxAlreadyExists(bytes32 txID);
     error TxAlreadyVerified(bytes32 txID);

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -14,6 +14,8 @@ interface ICrossError {
     error TxAlreadyVerified(bytes32 txID);
     error CoordinatorStateNotFound(bytes32 txID);
     error TxRunNotImplemented();
+    error ExtSignTxNotImplemented();
+    error TxAuthStateNotImplemented();
     error ModuleAlreadyInitialized();
     error ModuleNotInitialized();
     error PayloadDecodeFailed();

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -115,8 +115,10 @@ contract AuthenticatorTest is Test {
     function setUp() public {
         harness = new AuthenticatorHarness();
 
+        bytes memory expectedSignerId = abi.encodePacked(address(this));
+
         bytes[] memory signers = new bytes[](1);
-        signers[0] = signerABytes;
+        signers[0] = expectedSignerId;
 
         baseMsg = MsgSignTx.Data({
             txID: bytes("test-tx-id"),
@@ -151,6 +153,32 @@ contract AuthenticatorTest is Test {
         assertTrue(harness.completed(txIDHash), "Mock: auth should be completed");
         assertEq(harness.runTxCount(), 1, "Mock: runTxIfCompleted should be called once");
         assertEq(harness.lastRunTxID(), txIDHash, "Mock: runTxIfCompleted called with correct txID");
+    }
+
+    function test_signTx_RevertsIf_SignersLengthZero() public {
+        baseMsg.signers = new bytes[](0);
+
+        vm.expectRevert(ICrossError.InvalidSignersLength.selector);
+        harness.signTx(baseMsg);
+    }
+
+    function test_signTx_RevertsIf_SignersLengthMultiple() public {
+        bytes[] memory signers = new bytes[](2);
+        signers[0] = signerABytes;
+        signers[1] = signerBBytes;
+        baseMsg.signers = signers;
+
+        vm.expectRevert(ICrossError.InvalidSignersLength.selector);
+        harness.signTx(baseMsg);
+    }
+
+    function test_signTx_RevertsIf_SignerNotEqualSender() public {
+        bytes[] memory signers = new bytes[](1);
+        signers[0] = abi.encodePacked(address(0x12345));
+        baseMsg.signers = signers;
+
+        vm.expectRevert(ICrossError.SignerMustEqualSender.selector);
+        harness.signTx(baseMsg);
     }
 
     function test_extSignTx_RevertsNotImplemented() public {

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// solhint-disable one-contract-per-file, func-name-mixedcase, var-name-mixedcase, gas-small-strings
+pragma solidity ^0.8.20;
+
+import "forge-std/src/Test.sol";
+import "../src/core/Authenticator.sol";
+import {TxManagerBase} from "../src/core/TxManagerBase.sol";
+import {TxAuthManagerBase} from "../src/core/TxAuthManagerBase.sol";
+
+import {MsgInitiateTx} from "../src/proto/cross/core/initiator/Initiator.sol";
+import {IAuthenticator} from "../src/core/IAuthenticator.sol";
+import {
+    Account as AuthAccount,
+    AuthType,
+    TxAuthState,
+    MsgSignTx,
+    MsgSignTxResponse,
+    MsgExtSignTx,
+    QueryTxAuthStateRequest
+} from "../src/proto/cross/core/auth/Auth.sol";
+import {IbcCoreClientV1Height} from "../src/proto/ibc/core/client/v1/client.sol";
+
+contract MockTxManager is TxManagerBase {
+    bytes32 public lastRunTxID;
+    uint256 public runTxCount;
+
+    function _createTx(
+        bytes32,
+        /*txID*/
+        MsgInitiateTx.Data calldata /*src*/
+    )
+        internal
+        virtual
+        override
+    {}
+
+    function _runTxIfCompleted(bytes32 txID) internal virtual override {
+        lastRunTxID = txID;
+        ++runTxCount;
+    }
+
+    function _isTxRecorded(
+        bytes32 /*txID*/
+    )
+        internal
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return false;
+    }
+}
+
+contract MockTxAuthManager is TxAuthManagerBase {
+    mapping(bytes32 => bool) public completed;
+    bool private _signReturns = false;
+
+    function _initAuthState(
+        bytes32,
+        /*txID*/
+        Account.Data[] memory /*signers*/
+    )
+        internal
+        virtual
+        override
+    {}
+
+    function _isCompletedAuth(
+        bytes32 /*txID*/
+    )
+        internal
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return false;
+    }
+
+    function _sign(
+        bytes32 txID,
+        Account.Data[] memory /*signers*/
+    )
+        internal
+        virtual
+        override
+        returns (bool)
+    {
+        if (_signReturns) {
+            completed[txID] = true;
+        }
+        return _signReturns;
+    }
+    function _getAuthState(bytes32) internal view virtual override returns (TxAuthState.Data memory) {}
+
+    function setSignReturns(bool returnsValue) public {
+        _signReturns = returnsValue;
+    }
+}
+
+contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager {
+    function exposed_buildLocalAccounts(bytes[] calldata signerIDs) public pure returns (AuthAccount.Data[] memory) {
+        return _buildLocalAccounts(signerIDs);
+    }
+}
+
+contract AuthenticatorTest is Test {
+    AuthenticatorHarness private harness;
+    MsgSignTx.Data private baseMsg;
+    bytes32 private txIDHash;
+    bytes private signerABytes = bytes("signerA");
+    bytes private signerBBytes = bytes("signerB");
+
+    function setUp() public {
+        harness = new AuthenticatorHarness();
+
+        bytes[] memory signers = new bytes[](1);
+        signers[0] = signerABytes;
+
+        baseMsg = MsgSignTx.Data({
+            txID: bytes("test-tx-id"),
+            signers: signers,
+            timeout_height: IbcCoreClientV1Height.Data(0, 0),
+            timeout_timestamp: 0
+        });
+
+        txIDHash = sha256(baseMsg.txID);
+    }
+
+    function test_signTx_SucceedsAsPending() public {
+        harness.setSignReturns(false);
+
+        MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
+        assertFalse(resp.tx_auth_completed, "response should indicate not completed");
+        assertEq(resp.log, "", "log should be empty");
+        assertFalse(harness.completed(txIDHash), "Mock: auth should not be completed");
+        assertEq(harness.runTxCount(), 0, "Mock: runTxIfCompleted should not be called");
+    }
+
+    function test_signTx_SucceedsAsCompletedAndEmitsEvent() public {
+        harness.setSignReturns(true);
+
+        vm.expectEmit(true, true, false, true, address(harness));
+        emit IAuthenticator.TxSigned(address(this), txIDHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+
+        MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
+
+        assertTrue(resp.tx_auth_completed, "response should indicate completed");
+        assertEq(resp.log, "", "log should be empty");
+        assertTrue(harness.completed(txIDHash), "Mock: auth should be completed");
+        assertEq(harness.runTxCount(), 1, "Mock: runTxIfCompleted should be called once");
+        assertEq(harness.lastRunTxID(), txIDHash, "Mock: runTxIfCompleted called with correct txID");
+    }
+
+    function test_extSignTx_RevertsNotImplemented() public {
+        MsgExtSignTx.Data memory msg_;
+        msg_.txID = bytes("ext-tx");
+        msg_.signers = new AuthAccount.Data[](0);
+
+        vm.expectRevert(ICrossError.ExtSignTxNotImplemented.selector);
+        harness.extSignTx(msg_);
+    }
+
+    function test_txAuthState_RevertsNotImplemented() public {
+        QueryTxAuthStateRequest.Data memory req;
+        req.txID = bytes("query-tx");
+
+        vm.expectRevert(ICrossError.TxAuthStateNotImplemented.selector);
+        harness.txAuthState(req);
+    }
+
+    function test_buildLocalAccounts_BuildsCorrectly() public {
+        bytes[] memory signerIDs = new bytes[](2);
+        signerIDs[0] = signerABytes;
+        signerIDs[1] = signerBBytes;
+
+        AuthAccount.Data[] memory accounts = harness.exposed_buildLocalAccounts(signerIDs);
+
+        assertEq(accounts.length, 2, "Array length mismatch");
+
+        assertEq(accounts[0].id, signerABytes, "Signer A ID mismatch");
+        assertEq(
+            uint256(accounts[0].auth_type.mode),
+            uint256(AuthType.AuthMode.AUTH_MODE_LOCAL),
+            "Signer A auth type mismatch"
+        );
+        assertEq(accounts[0].auth_type.option.type_url, "", "Signer A option type_url should be empty");
+        assertEq(accounts[0].auth_type.option.value, "", "Signer A option value should be empty");
+
+        assertEq(accounts[1].id, signerBBytes, "Signer B ID mismatch");
+        assertEq(
+            uint256(accounts[1].auth_type.mode),
+            uint256(AuthType.AuthMode.AUTH_MODE_LOCAL),
+            "Signer B auth type mismatch"
+        );
+        assertEq(accounts[1].auth_type.option.type_url, "", "Signer B option type_url should be empty");
+        assertEq(accounts[1].auth_type.option.value, "", "Signer B option value should be empty");
+    }
+}


### PR DESCRIPTION
- Implemented `Authenticator.sol` and `signTx()`.
- Implemented unit tests for `signTx` and its helper functions.

## Contract Size

```
| Contract                                             | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
| CrossSimpleModule                                    | 19,212           | 20,191            | 5,364              | 28,961              |
| TxAuthManager                                        | 4,209            | 4,236             | 20,367             | 44,916              |
| TxManager                                            | 4,281            | 4,308             | 20,295             | 44,844              |
```

## Architecture

```mermaid
graph TD
    subgraph " "
        direction LR
        CrossSimpleModule
    end

    subgraph "Core Module (Execution Context)"
        direction TB
        CrossModule[(CrossModule)]
        Initiator
        Authenticator
        DelegatedLogicHandler
    end

    subgraph "Logic Implementations (Separate Contracts)"
        direction TB
        style TxAuthManager fill:#e6ffed,stroke:#006400,stroke-width:2px
        style TxManager fill:#e6ffed,stroke:#006400,stroke-width:2px
        
        TxAuthManager
        TxManager
    end

    subgraph "Bases & Implementations (Internal)"
        direction TB
        style TxAuthManagerBase fill:#f0f0f0,stroke:#333,stroke-width:2px
        style TxManagerBase fill:#f0f0f0,stroke:#333,stroke-width:2px
        style TxRunnerBase fill:#f0f0f0,stroke:#333,stroke-width:2px
        style TxRunner fill:#f5f5f5,stroke:#555,stroke-width:1px

        TxAuthManagerBase(("TxAuthManagerBase"))
        TxManagerBase(("TxManagerBase"))
        TxRunnerBase(("TxRunnerBase"))
        TxRunner["TxRunner"] -- "implements" --> TxRunnerBase
    end

    subgraph "Interfaces (External APIs)"
        direction TB
        style ITxAuthManager fill:#e6f7ff,stroke:#0056b3,stroke-width:2px
        style ITxManager fill:#e6f7ff,stroke:#0056b3,stroke-width:2px
        style IInitiator fill:#e6f7ff,stroke:#0056b3,stroke-width:2px
        style IAuthenticator fill:#e6f7ff,stroke:#0056b3,stroke-width:2px

        ITxAuthManager{{"ITxAuthManager"}}
        ITxManager{{"ITxManager"}}
        IInitiator{{"IInitiator"}}
        IAuthenticator{{"IAuthenticator"}}
    end

    subgraph "Storage (ERC-7201)"
        direction TB
        style CrossStore fill:#fffbe6,stroke:#d4a017,stroke-width:2px
        CrossStore
    end

    %% --- Links ---
    CrossSimpleModule -- "inherits" --> CrossModule

    %% Core Module Inheritance
    CrossModule -- "inherits" --> Initiator
    CrossModule -- "inherits" --> Authenticator
    CrossModule -- "inherits" --> DelegatedLogicHandler
    CrossModule -- "inherits" --> CrossStore

    %% Logic Handler (Bridge)
    DelegatedLogicHandler -- "implements" --> TxAuthManagerBase
    DelegatedLogicHandler -- "implements" --> TxManagerBase
    DelegatedLogicHandler -. "uses" .-> ITxAuthManager
    DelegatedLogicHandler -. "uses" .-> ITxManager
    DelegatedLogicHandler -. "delegatecall<br>staticcall" .-> TxAuthManager
    DelegatedLogicHandler -. "delegatecall<br>staticcall" .-> TxManager

    %% Core Logic Components
    Initiator -- "implements" --> IInitiator
    Initiator -- "inherits" --> TxAuthManagerBase
    Initiator -- "inherits" --> TxManagerBase

    Authenticator -- "implements" --> IAuthenticator
    Authenticator -- "inherits" --> TxAuthManagerBase
    Authenticator -- "inherits" --> TxManagerBase

    %% Logic Contract Inheritance
    TxAuthManager -- "implements" --> ITxAuthManager
    TxAuthManager -- "inherits" --> TxAuthManagerBase
    TxAuthManager -- "inherits" --> CrossStore

    TxManager -- "implements" --> ITxManager
    TxManager -- "inherits" --> TxManagerBase
    TxManager -- "inherits" --> TxRunner
    TxManager -- "inherits" --> CrossStore

```