### PR TITLE
feat: implement extSignTx function

### DIFF
--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -36,6 +36,8 @@ import {TxAuthManager} from "src/core/TxAuthManager.sol";
 import {TxManager} from "src/core/TxManager.sol";
 import {MockClient} from "@hyperledger-labs/yui-ibc-solidity/contracts/clients/mock/MockClient.sol";
 import {MockCrossContract} from "src/example/MockCrossContract.sol";
+import {SampleExtensionVerifier} from "src/example/SampleExtensionVerifier.sol";
+import {IAuthExtensionVerifier} from "src/core/IAuthExtensionVerifier.sol";
 
 import {IIBCModuleInitializer} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/26-router/IIBCModule.sol";
 import {ILightClient} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/02-client/ILightClient.sol";
@@ -71,7 +73,16 @@ contract DeployAll is Script, Config {
         MockCrossContract app = new MockCrossContract();
         console2.log("  MockCrossContract:", address(app));
 
-        TxAuthManager txAuthManager = new TxAuthManager();
+        SampleExtensionVerifier verifier = new SampleExtensionVerifier();
+        console2.log("  SampleExtensionVerifier:", address(verifier));
+
+        string[] memory typeUrls = new string[](1);
+        typeUrls[0] = "/verifier.sample.extension";
+
+        IAuthExtensionVerifier[] memory verifiers = new IAuthExtensionVerifier[](1);
+        verifiers[0] = IAuthExtensionVerifier(verifier);
+
+        TxAuthManager txAuthManager = new TxAuthManager(typeUrls, verifiers);
         console2.log("  TxAuthManager:", address(txAuthManager));
 
         TxManager txManager = new TxManager();

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -34,14 +34,19 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
         return MsgSignTxResponse.Data({tx_auth_completed: completed, log: ""});
     }
 
-    function extSignTx(
-        MsgExtSignTx.Data calldata /*msg_*/
-    )
-        external
-        override
-        returns (MsgExtSignTxResponse.Data memory)
-    {
-        revert ExtSignTxNotImplemented();
+    function extSignTx(MsgExtSignTx.Data calldata msg_) external override returns (MsgExtSignTxResponse.Data memory) {
+        bytes32 txIDHash = sha256(msg_.txID);
+
+        _verifySignatures(txIDHash, msg_.signers);
+
+        bool completed = _sign(txIDHash, msg_.signers);
+        if (completed) {
+            _runTxIfCompleted(txIDHash);
+        }
+
+        emit TxSigned(msg.sender, txIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+
+        return MsgExtSignTxResponse.Data({x: true});
     }
 
     function txAuthState(

--- a/src/core/CrossStore.sol
+++ b/src/core/CrossStore.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.20;
 
+import {IAuthExtensionVerifier} from "./IAuthExtensionVerifier.sol";
 import {MsgInitiateTx, MsgInitiateTxResponse} from "../proto/cross/core/initiator/Initiator.sol";
 import {Account} from "../proto/cross/core/auth/Auth.sol";
 import {CoordinatorState} from "src/proto/cross/core/atomic/simple/AtomicSimple.sol";
@@ -19,6 +20,7 @@ abstract contract CrossStore {
         hex"ef61b39f0bec0016a7c6e65e3ee8d2ea1b2327afbd737de3be2c6827c42f9600";
 
     struct AuthStorage {
+        mapping(string => IAuthExtensionVerifier) authVerifiers;
         mapping(bytes32 => mapping(bytes32 => bool)) remaining;
         mapping(bytes32 => uint256) remainingCount;
         mapping(bytes32 => bool) authInitialized;

--- a/src/core/DelegatedLogicHandler.sol
+++ b/src/core/DelegatedLogicHandler.sol
@@ -42,6 +42,12 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
         return abi.decode(ret, (TxAuthState.Data));
     }
 
+    function _verifySignatures(bytes32 txIDHash, Account.Data[] calldata signers) internal virtual override {
+        _delegateWithData(
+            TX_AUTH_MANAGER, abi.encodeWithSelector(ITxAuthManager.verifySignatures.selector, txIDHash, signers)
+        );
+    }
+
     function _createTx(bytes32 txID, MsgInitiateTx.Data calldata src) internal virtual override {
         _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.createTx.selector, txID, src));
     }

--- a/src/core/IAuthExtensionVerifier.sol
+++ b/src/core/IAuthExtensionVerifier.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import {Account} from "../proto/cross/core/auth/Auth.sol";
+
+interface IAuthExtensionVerifier {
+    function verify(bytes32 txIDHash, Account.Data calldata signer) external view returns (bool isValid);
+}

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -22,7 +22,6 @@ interface ICrossError {
     error ArrayLengthMismatch();
     error EmptyTypeUrl();
     error ZeroAddressVerifier();
-    error VerifierCallFailed(string typeUrl);
     error VerifierReturnedFalse(bytes32 txIDHash, string typeUrl);
     error TooManySigners(uint256 got, uint256 maxAllowed);
     error TxRunNotImplemented();

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -13,8 +13,17 @@ interface ICrossError {
     error TxAlreadyExists(bytes32 txID);
     error TxAlreadyVerified(bytes32 txID);
     error CoordinatorStateNotFound(bytes32 txID);
+    error SignerCountMismatch(uint256 signerCount, uint256 signatureCount);
+    error AuthModeMismatch();
+    error VerifierNotFound(string typeUrl);
+    error SignatureVerificationFailed(bytes32 txID);
+    error ArrayLengthMismatch();
+    error EmptyTypeUrl();
+    error ZeroAddressVerifier();
+    error VerifierStaticCallFailed(string typeUrl);
+    error VerifierReturnedFalse(bytes32 txIDHash, string typeUrl);
+    error TooManySigners(uint256 got, uint256 maxAllowed);
     error TxRunNotImplemented();
-    error ExtSignTxNotImplemented();
     error TxAuthStateNotImplemented();
     error ModuleAlreadyInitialized();
     error ModuleNotInitialized();

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -22,7 +22,7 @@ interface ICrossError {
     error ArrayLengthMismatch();
     error EmptyTypeUrl();
     error ZeroAddressVerifier();
-    error VerifierStaticCallFailed(string typeUrl);
+    error VerifierCallFailed(string typeUrl);
     error VerifierReturnedFalse(bytes32 txIDHash, string typeUrl);
     error TooManySigners(uint256 got, uint256 maxAllowed);
     error TxRunNotImplemented();

--- a/src/core/ITxAuthManager.sol
+++ b/src/core/ITxAuthManager.sol
@@ -8,4 +8,5 @@ interface ITxAuthManager {
     function isCompletedAuth(bytes32 txID) external returns (bool);
     function sign(bytes32 txID, Account.Data[] calldata signers) external returns (bool);
     function getAuthState(bytes32 txID) external returns (TxAuthState.Data memory);
+    function verifySignatures(bytes32 txIDHash, Account.Data[] calldata signers) external;
 }

--- a/src/core/TxAuthManager.sol
+++ b/src/core/TxAuthManager.sol
@@ -106,15 +106,12 @@ contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossE
                 revert VerifierNotFound(typeUrl);
             }
 
-            bytes memory callData = abi.encodeWithSelector(IAuthExtensionVerifier.verify.selector, txIDHash, signer);
-
-            (bool ok, bytes memory ret) = address(verifier).staticcall(callData);
-            if (!ok) {
-                revert VerifierStaticCallFailed(typeUrl);
-            }
-            bool verified = abi.decode(ret, (bool));
-            if (!verified) {
-                revert VerifierReturnedFalse(txIDHash, typeUrl);
+            try verifier.verify(txIDHash, signer) returns (bool verified) {
+                if (!verified) {
+                    revert VerifierReturnedFalse(txIDHash, typeUrl);
+                }
+            } catch {
+                revert VerifierCallFailed(typeUrl);
             }
         }
         // slither-disable-end calls-loop

--- a/src/core/TxAuthManager.sol
+++ b/src/core/TxAuthManager.sol
@@ -3,11 +3,30 @@ pragma solidity ^0.8.20;
 
 import {TxAuthManagerBase} from "./TxAuthManagerBase.sol";
 import {CrossStore} from "./CrossStore.sol";
-import {Account, TxAuthState} from "../proto/cross/core/auth/Auth.sol";
+import {Account, TxAuthState, AuthType} from "../proto/cross/core/auth/Auth.sol";
 import {ITxAuthManager} from "./ITxAuthManager.sol";
+import {IAuthExtensionVerifier} from "./IAuthExtensionVerifier.sol";
 import {ICrossError} from "./ICrossError.sol";
 
 contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossError {
+    uint256 private constant MAX_SIGNERS_PER_TX = 32;
+
+    constructor(string[] memory typeUrls, IAuthExtensionVerifier[] memory verifiers) {
+        if (typeUrls.length != verifiers.length) revert ArrayLengthMismatch();
+
+        CrossStore.AuthStorage storage s = _getAuthStorage();
+
+        for (uint256 i = 0; i < typeUrls.length; ++i) {
+            string memory typeUrl = typeUrls[i];
+            IAuthExtensionVerifier verifier = verifiers[i];
+
+            if (bytes(typeUrl).length == 0) revert EmptyTypeUrl();
+            if (address(verifier) == address(0)) revert ZeroAddressVerifier();
+
+            s.authVerifiers[typeUrl] = verifier;
+        }
+    }
+
     function initAuthState(bytes32 txID, Account.Data[] calldata signers) external override {
         _initAuthState(txID, signers);
     }
@@ -22,6 +41,10 @@ contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossE
 
     function getAuthState(bytes32 txID) external override returns (TxAuthState.Data memory) {
         return _getAuthState(txID);
+    }
+
+    function verifySignatures(bytes32 txIDHash, Account.Data[] calldata signers) external override {
+        _verifySignatures(txIDHash, signers);
     }
 
     function _initAuthState(bytes32 txID, Account.Data[] memory signers) internal virtual override {
@@ -58,6 +81,43 @@ contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossE
         if (!s.authInitialized[txID]) revert IDNotFound(txID);
         Account.Data[] memory remains = _getRemainingSigners(s, txID);
         return TxAuthState.Data({remaining_signers: remains});
+    }
+
+    function _verifySignatures(bytes32 txIDHash, Account.Data[] calldata signers) internal virtual override {
+        uint256 len = signers.length;
+
+        if (len > MAX_SIGNERS_PER_TX) {
+            revert TooManySigners(len, MAX_SIGNERS_PER_TX);
+        }
+
+        CrossStore.AuthStorage storage s = _getAuthStorage();
+
+        // slither-disable-start calls-loop
+        for (uint256 i = 0; i < len; ++i) {
+            Account.Data calldata signer = signers[i];
+
+            if (signer.auth_type.mode != AuthType.AuthMode.AUTH_MODE_EXTENSION) {
+                revert AuthModeMismatch();
+            }
+
+            string calldata typeUrl = signer.auth_type.option.type_url;
+            IAuthExtensionVerifier verifier = s.authVerifiers[typeUrl];
+            if (address(verifier) == address(0)) {
+                revert VerifierNotFound(typeUrl);
+            }
+
+            bytes memory callData = abi.encodeWithSelector(IAuthExtensionVerifier.verify.selector, txIDHash, signer);
+
+            (bool ok, bytes memory ret) = address(verifier).staticcall(callData);
+            if (!ok) {
+                revert VerifierStaticCallFailed(typeUrl);
+            }
+            bool verified = abi.decode(ret, (bool));
+            if (!verified) {
+                revert VerifierReturnedFalse(txIDHash, typeUrl);
+            }
+        }
+        // slither-disable-end calls-loop
     }
 
     function _getRemainingSigners(CrossStore.AuthStorage storage s, bytes32 txID)

--- a/src/core/TxAuthManager.sol
+++ b/src/core/TxAuthManager.sol
@@ -106,12 +106,9 @@ contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossE
                 revert VerifierNotFound(typeUrl);
             }
 
-            try verifier.verify(txIDHash, signer) returns (bool verified) {
-                if (!verified) {
-                    revert VerifierReturnedFalse(txIDHash, typeUrl);
-                }
-            } catch {
-                revert VerifierCallFailed(typeUrl);
+            bool verified = verifier.verify(txIDHash, signer);
+            if (!verified) {
+                revert VerifierReturnedFalse(txIDHash, typeUrl);
             }
         }
         // slither-disable-end calls-loop

--- a/src/core/TxAuthManagerBase.sol
+++ b/src/core/TxAuthManagerBase.sol
@@ -8,4 +8,5 @@ abstract contract TxAuthManagerBase {
     function _isCompletedAuth(bytes32 txID) internal virtual returns (bool);
     function _sign(bytes32 txID, Account.Data[] memory signers) internal virtual returns (bool);
     function _getAuthState(bytes32 txID) internal virtual returns (TxAuthState.Data memory);
+    function _verifySignatures(bytes32 txIDHash, Account.Data[] calldata signers) internal virtual;
 }

--- a/src/example/SampleExtensionVerifier.sol
+++ b/src/example/SampleExtensionVerifier.sol
@@ -8,6 +8,47 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 contract SampleExtensionVerifier is IAuthExtensionVerifier {
+    /**
+     * Expected inputs:
+     *
+     * @param txIDHash (1st argument, ignored in this implementation)
+     *  - Hash that uniquely identifies the transaction being verified.
+     *  - Not used in this sample implementation, but expected to be passed so
+     *    the caller can associate verification with a specific transaction.
+     *
+     * @param signer (2nd argument: Account.Data)
+     *  - signer.id:
+     *      - 20-byte value representing the signer’s Ethereum address.
+     *      - Must satisfy: signer.id.length == 20.
+     *      - The expected address is reconstructed as: address(bytes20(signer.id)).
+     *
+     *  - signer.auth_type.mode:
+     *      - Must be AuthType.AuthMode.AUTH_MODE_EXTENSION.
+     *      - Any other mode is treated as invalid and verification will fail.
+     *
+     *  - signer.auth_type.option.value:
+     *      - ABI-encoded as: abi.encode(signature, signMSG).
+     *        * signature:
+     *            - ECDSA signature over signMSG, in standard Ethereum format
+     *              (65 bytes: r(32) | s(32) | v(1)).
+     *        * signMSG:
+     *            - 32-byte message hash that was signed.
+     *            - On-chain, this contract applies:
+     *                MessageHashUtils.toEthSignedMessageHash(signMSG)
+     *              and expects `signature` to be a valid Ethereum signed message
+     *              for that value.
+     *
+     * Return value:
+     *  - true:
+     *      - When the recovered address from the signature is non-zero and
+     *        exactly matches address(bytes20(signer.id)).
+     *  - false:
+     *      - When:
+     *          * auth_type.mode is not AUTH_MODE_EXTENSION, or
+     *          * signer.id length is not 20 bytes, or
+     *          * signature recovery fails, or
+     *          * the recovered address does not match the expected address.
+     */
     function verify(
         bytes32,
         /*txIDHash*/

--- a/src/example/SampleExtensionVerifier.sol
+++ b/src/example/SampleExtensionVerifier.sol
@@ -11,12 +11,12 @@ contract SampleExtensionVerifier is IAuthExtensionVerifier {
     /**
      * Expected inputs:
      *
-     * @param txIDHash (1st argument, ignored in this implementation)
+     * param txIDHash (1st argument, ignored in this implementation)
      *  - Hash that uniquely identifies the transaction being verified.
      *  - Not used in this sample implementation, but expected to be passed so
      *    the caller can associate verification with a specific transaction.
      *
-     * @param signer (2nd argument: Account.Data)
+     * param signer (2nd argument: Account.Data)
      *  - signer.id:
      *      - 20-byte value representing the signer’s Ethereum address.
      *      - Must satisfy: signer.id.length == 20.

--- a/src/example/SampleExtensionVerifier.sol
+++ b/src/example/SampleExtensionVerifier.sol
@@ -74,6 +74,6 @@ contract SampleExtensionVerifier is IAuthExtensionVerifier {
 
         address recoveredAddress = ECDSA.recover(messageHash, signature);
 
-        return recoveredAddress != address(0) && recoveredAddress == expectedAddress;
+        return recoveredAddress == expectedAddress;
     }
 }

--- a/src/example/SampleExtensionVerifier.sol
+++ b/src/example/SampleExtensionVerifier.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
+
+import {IAuthExtensionVerifier} from "../core/IAuthExtensionVerifier.sol";
+import {AuthType, Account} from "../proto/cross/core/auth/Auth.sol";
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+contract SampleExtensionVerifier is IAuthExtensionVerifier {
+    function verify(bytes32 txIDHash, Account.Data calldata signer) external view override returns (bool isValid) {
+        if (signer.auth_type.mode != AuthType.AuthMode.AUTH_MODE_EXTENSION) {
+            return false;
+        }
+
+        (bytes memory signature, bytes32 sign_msg) = abi.decode(signer.auth_type.option.value, (bytes, bytes32));
+
+        if (signer.id.length != 20) {
+            return false;
+        }
+        address expectedAddress = address(bytes20(signer.id));
+
+        bytes32 messageHash = MessageHashUtils.toEthSignedMessageHash(sign_msg);
+
+        address recoveredAddress = ECDSA.recover(messageHash, signature);
+
+        return recoveredAddress != address(0) && recoveredAddress == expectedAddress;
+    }
+}

--- a/src/example/SampleExtensionVerifier.sol
+++ b/src/example/SampleExtensionVerifier.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.20;
 
-import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
-
 import {IAuthExtensionVerifier} from "../core/IAuthExtensionVerifier.sol";
 import {AuthType, Account} from "../proto/cross/core/auth/Auth.sol";
 
@@ -10,19 +8,28 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 contract SampleExtensionVerifier is IAuthExtensionVerifier {
-    function verify(bytes32 txIDHash, Account.Data calldata signer) external view override returns (bool isValid) {
+    function verify(
+        bytes32,
+        /*txIDHash*/
+        Account.Data calldata signer
+    )
+        external
+        view
+        override
+        returns (bool isValid)
+    {
         if (signer.auth_type.mode != AuthType.AuthMode.AUTH_MODE_EXTENSION) {
             return false;
         }
 
-        (bytes memory signature, bytes32 sign_msg) = abi.decode(signer.auth_type.option.value, (bytes, bytes32));
+        (bytes memory signature, bytes32 signMSG) = abi.decode(signer.auth_type.option.value, (bytes, bytes32));
 
         if (signer.id.length != 20) {
             return false;
         }
         address expectedAddress = address(bytes20(signer.id));
 
-        bytes32 messageHash = MessageHashUtils.toEthSignedMessageHash(sign_msg);
+        bytes32 messageHash = MessageHashUtils.toEthSignedMessageHash(signMSG);
 
         address recoveredAddress = ECDSA.recover(messageHash, signature);
 

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -222,7 +222,7 @@ contract AuthenticatorTest is Test {
     function test_extSignTx_SucceedsAsPending() public {
         harness.setSignReturns(false);
 
-        vm.expectEmit(true, true, false, true, address(harness));
+        vm.expectEmit(address(harness));
         emit IAuthenticator.TxSigned(address(this), extTxIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);
@@ -235,7 +235,7 @@ contract AuthenticatorTest is Test {
     function test_extSignTx_SucceedsAsCompletedAndEmitsEvent() public {
         harness.setSignReturns(true);
 
-        vm.expectEmit(true, true, false, true, address(harness));
+        vm.expectEmit(address(harness));
         emit IAuthenticator.TxSigned(address(this), extTxIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -55,6 +55,9 @@ contract MockTxManager is TxManagerBase {
 contract MockTxAuthManager is TxAuthManagerBase {
     mapping(bytes32 => bool) public completed;
     bool private _signReturns = false;
+    bool private _verifyShouldRevert = false;
+
+    error MockVerifyError();
 
     function _initAuthState(
         bytes32,
@@ -94,8 +97,27 @@ contract MockTxAuthManager is TxAuthManagerBase {
     }
     function _getAuthState(bytes32) internal view virtual override returns (TxAuthState.Data memory) {}
 
+    function _verifySignatures(
+        bytes32,
+        /*txIDHash*/
+        AuthAccount.Data[] calldata
+        /*signers*/
+    )
+        internal
+        virtual
+        override
+    {
+        if (_verifyShouldRevert) {
+            revert MockVerifyError();
+        }
+    }
+
     function setSignReturns(bool returnsValue) public {
         _signReturns = returnsValue;
+    }
+
+    function setVerifyShouldRevert(bool shouldRevert) public {
+        _verifyShouldRevert = shouldRevert;
     }
 }
 
@@ -109,6 +131,8 @@ contract AuthenticatorTest is Test {
     AuthenticatorHarness private harness;
     MsgSignTx.Data private baseMsg;
     bytes32 private txIDHash;
+    MsgExtSignTx.Data private extMsg;
+    bytes32 private extTxIDHash;
     bytes private signerABytes = bytes("signerA");
     bytes private signerBBytes = bytes("signerB");
 
@@ -126,6 +150,20 @@ contract AuthenticatorTest is Test {
         });
 
         txIDHash = sha256(baseMsg.txID);
+
+        bytes memory extTxID = bytes("ext-test-tx-id");
+        extTxIDHash = sha256(extTxID);
+
+        AuthAccount.Data[] memory extSigners = new AuthAccount.Data[](1);
+        extSigners[0] = AuthAccount.Data({
+            id: signerABytes,
+            auth_type: AuthType.Data({
+                mode: AuthType.AuthMode.AUTH_MODE_EXTENSION,
+                option: GoogleProtobufAny.Data({type_url: "/verifier/test", value: ""})
+            })
+        });
+
+        extMsg = MsgExtSignTx.Data({txID: extTxID, signers: extSigners});
     }
 
     function test_signTx_SucceedsAsPending() public {
@@ -153,13 +191,38 @@ contract AuthenticatorTest is Test {
         assertEq(harness.lastRunTxID(), txIDHash, "Mock: runTxIfCompleted called with correct txID");
     }
 
-    function test_extSignTx_RevertsNotImplemented() public {
-        MsgExtSignTx.Data memory msg_;
-        msg_.txID = bytes("ext-tx");
-        msg_.signers = new AuthAccount.Data[](0);
+    function test_extSignTx_SucceedsAsPending() public {
+        harness.setSignReturns(false);
 
-        vm.expectRevert(ICrossError.ExtSignTxNotImplemented.selector);
-        harness.extSignTx(msg_);
+        vm.expectEmit(true, true, false, true, address(harness));
+        emit IAuthenticator.TxSigned(address(this), extTxIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+
+        MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);
+
+        assertTrue(resp.x, "response.x should be true");
+        assertFalse(harness.completed(extTxIDHash), "Mock: auth should not be completed");
+        assertEq(harness.runTxCount(), 0, "Mock: runTxIfCompleted should not be called");
+    }
+
+    function test_extSignTx_SucceedsAsCompletedAndEmitsEvent() public {
+        harness.setSignReturns(true);
+
+        vm.expectEmit(true, true, false, true, address(harness));
+        emit IAuthenticator.TxSigned(address(this), extTxIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+
+        MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);
+
+        assertTrue(resp.x, "response.x should be true");
+        assertTrue(harness.completed(extTxIDHash), "Mock: auth should be completed");
+        assertEq(harness.runTxCount(), 1, "Mock: runTxIfCompleted should be called once");
+        assertEq(harness.lastRunTxID(), extTxIDHash, "Mock: runTxIfCompleted called with correct txID");
+    }
+
+    function test_extSignTx_RevertsIfVerificationFails() public {
+        harness.setVerifyShouldRevert(true);
+
+        vm.expectRevert(MockTxAuthManager.MockVerifyError.selector);
+        harness.extSignTx(extMsg);
     }
 
     function test_txAuthState_RevertsNotImplemented() public {

--- a/test/DelegatedLogicHandler.t.sol
+++ b/test/DelegatedLogicHandler.t.sol
@@ -124,6 +124,10 @@ contract DelegatedLogicHandlerHarness is DelegatedLogicHandler, MockStore {
         return _getAuthState(txID);
     }
 
+    function exposed_verifySignatures(bytes32 txIDHash, AuthAccount.Data[] calldata signers) public {
+        _verifySignatures(txIDHash, signers);
+    }
+
     function exposed_createTx(bytes32 txID, MsgInitiateTx.Data calldata src) public {
         _createTx(txID, src);
     }
@@ -214,6 +218,12 @@ contract DelegatedLogicHandlerTest is Test {
         assertEq(harness.readAuth_callCount(txID), 1, "AuthManager.getAuthState should be called once");
         assertEq(result.remaining_signers.length, 1, "Return value (signers length) mismatch");
         assertEq(result.remaining_signers[0].id, signers[0].id, "Return value (signer id) mismatch");
+    }
+
+    function test_verifySignatures_DelegatesToAuthManager() public {
+        harness.exposed_verifySignatures(txID, signers);
+
+        assertEq(harness.readAuth_callCount(txID), 1, "AuthManager.verifySignatures should be called once");
     }
 
     function test_createTx_DelegatesToTxManager() public {

--- a/test/DelegatedLogicHandler.t.sol
+++ b/test/DelegatedLogicHandler.t.sol
@@ -58,6 +58,10 @@ contract MockTxAuthManager is ITxAuthManager, MockStore {
 
         return TxAuthState.Data({remaining_signers: remaining});
     }
+
+    function verifySignatures(bytes32 txIDHash, AuthAccount.Data[] calldata) external override {
+        ++authStorage.callCounts[txIDHash];
+    }
 }
 
 contract MockTxManager is ITxManager, MockStore {

--- a/test/Initiator.t.sol
+++ b/test/Initiator.t.sol
@@ -73,6 +73,10 @@ contract MockTxAuthManager is TxAuthManagerBase {
         revert("MockTxAuthManager._getAuthState not implemented");
     }
 
+    function _verifySignatures(bytes32, AuthAccount.Data[] calldata) internal virtual override {
+        revert("MockTxAuthManager._verifySignatures not implemented");
+    }
+
     function setSignReturns(bool returnsValue) public {
         _signReturns = returnsValue;
     }

--- a/test/SampleExtensionVerifier.sol
+++ b/test/SampleExtensionVerifier.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// solhint-disable one-contract-per-file, func-name-mixedcase, gas-small-strings
+pragma solidity ^0.8.20;
+
+import "forge-std/src/Test.sol";
+import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
+
+import {SampleExtensionVerifier} from "../src/example/SampleExtensionVerifier.sol";
+import {Account as AuthAccount, AuthType} from "../src/proto/cross/core/auth/Auth.sol";
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+contract SampleExtensionVerifierTest is Test {
+    SampleExtensionVerifier private verifier;
+
+    uint256 private signerPrivateKey = 0xBAD_5EED;
+    address private signerAddress;
+
+    bytes32 private txIDHash = keccak256("test_tx_id_hash");
+    bytes32 private signMsg = keccak256("message_to_be_signed");
+    bytes32 private ethSignedMsgHash;
+    bytes validSignature;
+
+    AuthAccount.Data private baseAuthAccount;
+
+    function setUp() public {
+        verifier = new SampleExtensionVerifier();
+
+        signerAddress = vm.addr(signerPrivateKey);
+
+        ethSignedMsgHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", signMsg));
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, ethSignedMsgHash);
+        validSignature = abi.encodePacked(r, s, v);
+
+        GoogleProtobufAny.Data memory option = GoogleProtobufAny.Data({
+            type_url: "SampleExtensionVerifier",
+            value: abi.encode(validSignature, signMsg) // (bytes, bytes32)
+        });
+
+        AuthType.Data memory authType = AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_EXTENSION, option: option});
+
+        baseAuthAccount = AuthAccount.Data({id: abi.encodePacked(signerAddress), auth_type: authType});
+    }
+
+    function test_verify_SucceedsWhenSignatureIsValid() public view {
+        bool isValid = verifier.verify(txIDHash, baseAuthAccount);
+        assertTrue(isValid, "Signature should be valid");
+    }
+
+    function test_verify_ReturnsFalseWhenAuthModeIsNotExtension() public view {
+        AuthAccount.Data memory modifiedAuthAccount = baseAuthAccount;
+        modifiedAuthAccount.auth_type.mode = AuthType.AuthMode.AUTH_MODE_LOCAL;
+
+        bool isValid = verifier.verify(txIDHash, modifiedAuthAccount);
+        assertFalse(isValid, "Should return false if mode is not EXTENSION");
+    }
+
+    function test_verify_ReturnsFalseWhenSignerIdMismatch() public view {
+        AuthAccount.Data memory modifiedAuthAccount = baseAuthAccount;
+        address otherAddress = address(0xDEADBEEF);
+        modifiedAuthAccount.id = abi.encodePacked(otherAddress);
+
+        bool isValid = verifier.verify(txIDHash, modifiedAuthAccount);
+        assertFalse(isValid, "Should return false if signer.id does not match recovered address");
+    }
+
+    function test_verify_ReturnsFalseWhenSignerIdIsInvalidLength() public view {
+        AuthAccount.Data memory modifiedAuthAccount = baseAuthAccount;
+        modifiedAuthAccount.id = bytes("not-an-address");
+
+        bool isValid = verifier.verify(txIDHash, modifiedAuthAccount);
+        assertFalse(isValid, "Should return false if signer.id length is not 20");
+    }
+
+    function test_verify_ReturnsFalseWhenSignedMsgMismatch() public view {
+        AuthAccount.Data memory modifiedAuthAccount = baseAuthAccount;
+        bytes32 otherMsg = keccak256("other_message");
+
+        modifiedAuthAccount.auth_type.option.value = abi.encode(validSignature, otherMsg);
+
+        bool isValid = verifier.verify(txIDHash, modifiedAuthAccount);
+        assertFalse(isValid, "Should return false if sign_msg does not match signature");
+    }
+
+    function test_verify_RevertsWhen_SignatureIsInvalidLength() public {
+        AuthAccount.Data memory modifiedAccount = baseAuthAccount;
+        bytes memory invalidSignature = hex"1234";
+        modifiedAccount.auth_type.option.value = abi.encode(invalidSignature, signMsg);
+
+        vm.expectRevert(abi.encodeWithSelector(ECDSA.ECDSAInvalidSignatureLength.selector, 2));
+        verifier.verify(txIDHash, modifiedAccount);
+    }
+
+    function test_verify_RevertsWhen_SignatureIsIncorrect() public {
+        AuthAccount.Data memory modifiedAccount = baseAuthAccount;
+
+        bytes32 r = bytes32(validSignature);
+        bytes32 s_tampered = r;
+        uint8 v = 28;
+
+        bytes memory tamperedSignature = abi.encodePacked(r, s_tampered, v);
+        modifiedAccount.auth_type.option.value = abi.encode(tamperedSignature, signMsg);
+
+        vm.expectRevert(abi.encodeWithSelector(ECDSA.ECDSAInvalidSignatureS.selector, s_tampered));
+        verifier.verify(txIDHash, modifiedAccount);
+    }
+
+    function test_verify_RevertsWhen_OptionDataIsMalformed() public {
+        AuthAccount.Data memory modifiedAuthAccount = baseAuthAccount;
+
+        modifiedAuthAccount.auth_type.option.value = bytes("this is not abi encoded");
+
+        vm.expectRevert();
+        verifier.verify(txIDHash, modifiedAuthAccount);
+    }
+}

--- a/test/SampleExtensionVerifier.sol
+++ b/test/SampleExtensionVerifier.sol
@@ -19,7 +19,7 @@ contract SampleExtensionVerifierTest is Test {
     bytes32 private txIDHash = keccak256("test_tx_id_hash");
     bytes32 private signMsg = keccak256("message_to_be_signed");
     bytes32 private ethSignedMsgHash;
-    bytes validSignature;
+    bytes private validSignature;
 
     AuthAccount.Data private baseAuthAccount;
 
@@ -96,13 +96,13 @@ contract SampleExtensionVerifierTest is Test {
         AuthAccount.Data memory modifiedAccount = baseAuthAccount;
 
         bytes32 r = bytes32(validSignature);
-        bytes32 s_tampered = r;
+        bytes32 sTampered = r;
         uint8 v = 28;
 
-        bytes memory tamperedSignature = abi.encodePacked(r, s_tampered, v);
+        bytes memory tamperedSignature = abi.encodePacked(r, sTampered, v);
         modifiedAccount.auth_type.option.value = abi.encode(tamperedSignature, signMsg);
 
-        vm.expectRevert(abi.encodeWithSelector(ECDSA.ECDSAInvalidSignatureS.selector, s_tampered));
+        vm.expectRevert(abi.encodeWithSelector(ECDSA.ECDSAInvalidSignatureS.selector, sTampered));
         verifier.verify(txIDHash, modifiedAccount);
     }
 

--- a/test/TxAuthManager.t.sol
+++ b/test/TxAuthManager.t.sol
@@ -462,7 +462,7 @@ contract TxAuthManagerTest is Test, ICrossError {
         AuthAccount.Data[] memory signers = new AuthAccount.Data[](1);
         signers[0] = extSignerReverting;
 
-        vm.expectRevert(abi.encodeWithSelector(VerifierCallFailed.selector, URL_REVERTING));
+        vm.expectRevert(bytes("MockRevertingVerifier: Staticcall failed"));
         harness.verifySignatures(txID, signers);
     }
 

--- a/test/TxAuthManager.t.sol
+++ b/test/TxAuthManager.t.sol
@@ -8,7 +8,29 @@ import "../src/core/TxAuthManager.sol";
 import {Account as AuthAccount, TxAuthState, AuthType} from "../src/proto/cross/core/auth/Auth.sol";
 import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
 
+contract MockValidVerifier is IAuthExtensionVerifier {
+    function verify(bytes32, AuthAccount.Data calldata) external view override returns (bool) {
+        return true;
+    }
+}
+
+contract MockInvalidVerifier is IAuthExtensionVerifier {
+    function verify(bytes32, AuthAccount.Data calldata) external view override returns (bool) {
+        return false;
+    }
+}
+
+contract MockRevertingVerifier is IAuthExtensionVerifier {
+    function verify(bytes32, AuthAccount.Data calldata) external view override returns (bool) {
+        revert("MockRevertingVerifier: Staticcall failed");
+    }
+}
+
 contract TxAuthManagerHarness is TxAuthManager {
+    constructor(string[] memory typeUrls, IAuthExtensionVerifier[] memory verifiers)
+        TxAuthManager(typeUrls, verifiers)
+    {}
+
     function exposed_accountKey(AuthAccount.Data memory a) public pure returns (bytes32) {
         return _accountKey(a);
     }
@@ -24,26 +46,141 @@ contract TxAuthManagerHarness is TxAuthManager {
     }
 }
 
-contract TxAuthManagerTest is Test {
+contract TxAuthManagerTest is Test, ICrossError {
     TxAuthManagerHarness private harness;
     bytes32 private txID = keccak256("test_tx_id");
+
+    // Auth Types
+    AuthType.Data private localAuthType;
+    AuthType.Data private extAuthTypeValid;
+    AuthType.Data private extAuthTypeInvalid;
+    AuthType.Data private extAuthTypeReverting;
+    AuthType.Data private extAuthTypeNotFound;
+
+    // Signer Accounts
     AuthAccount.Data private signerA;
     AuthAccount.Data private signerB;
     AuthAccount.Data private signerC;
-    AuthType.Data private localAuthType;
-    AuthType.Data private channelAuthType;
+    AuthAccount.Data private extSignerAValid;
+    AuthAccount.Data private extSignerBValid;
+    AuthAccount.Data private extSignerInvalid;
+    AuthAccount.Data private extSignerReverting;
+    AuthAccount.Data private extSignerNotFound;
+
+    // Verifier URLs
+    string private constant URL_VALID = "/verifier/valid";
+    string private constant URL_INVALID = "/verifier/invalid";
+    string private constant URL_REVERTING = "/verifier/reverting";
+    string private constant URL_NOT_FOUND = "/verifier/notfound";
 
     function setUp() public {
-        harness = new TxAuthManagerHarness();
+        // 1. Deploy Mock Verifiers
+        MockValidVerifier validVerifier = new MockValidVerifier();
+        MockInvalidVerifier invalidVerifier = new MockInvalidVerifier();
+        MockRevertingVerifier revertingVerifier = new MockRevertingVerifier();
 
+        // 2. Setup Verifier Arrays
+        string[] memory typeUrls = new string[](3);
+        typeUrls[0] = URL_VALID;
+        typeUrls[1] = URL_INVALID;
+        typeUrls[2] = URL_REVERTING;
+
+        IAuthExtensionVerifier[] memory verifiers = new IAuthExtensionVerifier[](3);
+        verifiers[0] = IAuthExtensionVerifier(validVerifier);
+        verifiers[1] = IAuthExtensionVerifier(invalidVerifier);
+        verifiers[2] = IAuthExtensionVerifier(revertingVerifier);
+
+        // 3. Deploy Harness
+        harness = new TxAuthManagerHarness(typeUrls, verifiers);
+
+        // 4. Setup Auth Types
         GoogleProtobufAny.Data memory emptyAny = GoogleProtobufAny.Data({type_url: "", value: ""});
         localAuthType = AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: emptyAny});
 
-        channelAuthType = AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_EXTENSION, option: emptyAny});
+        extAuthTypeValid = AuthType.Data({
+            mode: AuthType.AuthMode.AUTH_MODE_EXTENSION,
+            option: GoogleProtobufAny.Data({type_url: URL_VALID, value: ""})
+        });
+        extAuthTypeInvalid = AuthType.Data({
+            mode: AuthType.AuthMode.AUTH_MODE_EXTENSION,
+            option: GoogleProtobufAny.Data({type_url: URL_INVALID, value: ""})
+        });
+        extAuthTypeReverting = AuthType.Data({
+            mode: AuthType.AuthMode.AUTH_MODE_EXTENSION,
+            option: GoogleProtobufAny.Data({type_url: URL_REVERTING, value: ""})
+        });
+        extAuthTypeNotFound = AuthType.Data({
+            mode: AuthType.AuthMode.AUTH_MODE_EXTENSION,
+            option: GoogleProtobufAny.Data({type_url: URL_NOT_FOUND, value: ""})
+        });
 
+        // 5. Setup Signer Accounts
         signerA = AuthAccount.Data({id: bytes("signerA"), auth_type: localAuthType});
         signerB = AuthAccount.Data({id: bytes("signerB"), auth_type: localAuthType});
         signerC = AuthAccount.Data({id: bytes("signerC"), auth_type: localAuthType});
+
+        extSignerAValid = AuthAccount.Data({id: bytes("extSignerA"), auth_type: extAuthTypeValid});
+        extSignerBValid = AuthAccount.Data({id: bytes("extSignerB"), auth_type: extAuthTypeValid});
+        extSignerInvalid = AuthAccount.Data({id: bytes("extSignerInvalid"), auth_type: extAuthTypeInvalid});
+        extSignerReverting = AuthAccount.Data({id: bytes("extSignerReverting"), auth_type: extAuthTypeReverting});
+        extSignerNotFound = AuthAccount.Data({id: bytes("extSignerNotFound"), auth_type: extAuthTypeNotFound});
+    }
+
+    function test_constructor_SucceedsWithEmptyArrays() public {
+        string[] memory typeUrls = new string[](0);
+        IAuthExtensionVerifier[] memory verifiers = new IAuthExtensionVerifier[](0);
+
+        TxAuthManagerHarness localHarness = new TxAuthManagerHarness(typeUrls, verifiers);
+        assertTrue(address(localHarness) != address(0), "Harness should deploy");
+    }
+
+    function test_constructor_SucceedsAndEmitsEvents() public {
+        string[] memory typeUrls = new string[](2);
+        typeUrls[0] = URL_VALID;
+        typeUrls[1] = URL_INVALID;
+
+        IAuthExtensionVerifier[] memory verifiers = new IAuthExtensionVerifier[](2);
+        IAuthExtensionVerifier verifier1 = new MockValidVerifier();
+        IAuthExtensionVerifier verifier2 = new MockInvalidVerifier();
+        verifiers[0] = verifier1;
+        verifiers[1] = verifier2;
+
+        TxAuthManagerHarness localHarness = new TxAuthManagerHarness(typeUrls, verifiers);
+        assertTrue(address(localHarness) != address(0), "Harness should deploy");
+    }
+
+    function test_constructor_RevertWhen_ArrayLengthMismatch() public {
+        string[] memory typeUrls = new string[](1);
+        typeUrls[0] = URL_VALID;
+
+        IAuthExtensionVerifier[] memory verifiers = new IAuthExtensionVerifier[](2);
+        verifiers[0] = new MockValidVerifier();
+        verifiers[1] = new MockValidVerifier();
+
+        vm.expectRevert(ArrayLengthMismatch.selector);
+        new TxAuthManagerHarness(typeUrls, verifiers);
+    }
+
+    function test_constructor_RevertWhen_EmptyTypeUrl() public {
+        string[] memory typeUrls = new string[](1);
+        typeUrls[0] = "";
+
+        IAuthExtensionVerifier[] memory verifiers = new IAuthExtensionVerifier[](1);
+        verifiers[0] = new MockValidVerifier();
+
+        vm.expectRevert(EmptyTypeUrl.selector);
+        new TxAuthManagerHarness(typeUrls, verifiers);
+    }
+
+    function test_constructor_RevertWhen_ZeroAddressVerifier() public {
+        string[] memory typeUrls = new string[](1);
+        typeUrls[0] = URL_VALID;
+
+        IAuthExtensionVerifier[] memory verifiers = new IAuthExtensionVerifier[](1);
+        verifiers[0] = IAuthExtensionVerifier(address(0)); // Zero address
+
+        vm.expectRevert(ZeroAddressVerifier.selector);
+        new TxAuthManagerHarness(typeUrls, verifiers);
     }
 
     function test_initAuthState_Succeeds() public {
@@ -223,7 +360,7 @@ contract TxAuthManagerTest is Test {
         bytes32 keyB = harness.exposed_accountKey(signerB);
         assertNotEq(keyA, keyB, "Different IDs should produce different keys");
 
-        AuthAccount.Data memory signerAAltAuth = AuthAccount.Data({id: signerA.id, auth_type: channelAuthType});
+        AuthAccount.Data memory signerAAltAuth = AuthAccount.Data({id: signerA.id, auth_type: extAuthTypeValid});
         bytes32 keyAAltAuth = harness.exposed_accountKey(signerAAltAuth);
         assertNotEq(keyA, keyAAltAuth, "Different auth_types should produce different keys");
 
@@ -275,5 +412,65 @@ contract TxAuthManagerTest is Test {
 
         remaining = harness.exposed_getRemainingSigners(txID);
         assertEq(remaining.length, 0, "getRemainingSigners should return 0 signers");
+    }
+
+    function test_verifySignatures_SucceedsSingleSigner() public {
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](1);
+        signers[0] = extSignerAValid;
+
+        harness.verifySignatures(txID, signers);
+    }
+
+    function test_verifySignatures_SucceedsMultipleSigners() public {
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](2);
+        signers[0] = extSignerAValid;
+        signers[1] = extSignerBValid;
+
+        harness.verifySignatures(txID, signers);
+    }
+
+    function test_verifySignatures_RevertWhen_TooManySigners() public {
+        uint256 count = 33;
+
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](count);
+
+        for (uint256 i = 0; i < count; ++i) {
+            signers[i] = extSignerAValid;
+        }
+
+        vm.expectRevert(abi.encodeWithSelector(TooManySigners.selector, count, 32));
+        harness.verifySignatures(txID, signers);
+    }
+
+    function test_verifySignatures_RevertWhen_AuthModeMismatch() public {
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](1);
+        signers[0] = signerA;
+
+        vm.expectRevert(AuthModeMismatch.selector);
+        harness.verifySignatures(txID, signers);
+    }
+
+    function test_verifySignatures_RevertWhen_VerifierNotFound() public {
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](1);
+        signers[0] = extSignerNotFound;
+
+        vm.expectRevert(abi.encodeWithSelector(VerifierNotFound.selector, URL_NOT_FOUND));
+        harness.verifySignatures(txID, signers);
+    }
+
+    function test_verifySignatures_RevertWhen_StaticCallFails() public {
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](1);
+        signers[0] = extSignerReverting;
+
+        vm.expectRevert(abi.encodeWithSelector(VerifierStaticCallFailed.selector, URL_REVERTING));
+        harness.verifySignatures(txID, signers);
+    }
+
+    function test_verifySignatures_RevertWhen_VerifierReturnsFalse() public {
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](1);
+        signers[0] = extSignerInvalid;
+
+        vm.expectRevert(abi.encodeWithSelector(VerifierReturnedFalse.selector, txID, URL_INVALID));
+        harness.verifySignatures(txID, signers);
     }
 }

--- a/test/TxAuthManager.t.sol
+++ b/test/TxAuthManager.t.sol
@@ -462,7 +462,7 @@ contract TxAuthManagerTest is Test, ICrossError {
         AuthAccount.Data[] memory signers = new AuthAccount.Data[](1);
         signers[0] = extSignerReverting;
 
-        vm.expectRevert(abi.encodeWithSelector(VerifierStaticCallFailed.selector, URL_REVERTING));
+        vm.expectRevert(abi.encodeWithSelector(VerifierCallFailed.selector, URL_REVERTING));
         harness.verifySignatures(txID, signers);
     }
 


### PR DESCRIPTION
- Implemented `Authenticator.sol` and `extSignTx()`.
- Implemented unit tests for `extSignTx` and its helper functions.

## Contract Size

```
| Contract                                             | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
| CrossSimpleModule                                    | 19,534           | 20,513            | 5,042              | 28,639              |
| TxAuthManager                                        | 5,233            | 5,983             | 19,343             | 43,169              |
| TxManager                                            | 4,281            | 4,308             | 20,295             | 44,844              |
```