### PR TITLE
feat: implement txAuthState function

### DIFF
--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -22,11 +22,7 @@ import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/pr
 
 abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, CrossStore, ICrossError {
     function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
-        if (msg_.txID.length != 32) {
-            revert InvalidTxIDLength();
-        }
-
-        bytes32 txID = abi.decode(msg_.txID, (bytes32));
+        bytes32 txID = _decodeTxID(msg_.txID);
 
         if (msg_.signers.length != 1) {
             revert InvalidSignersLength();
@@ -50,11 +46,7 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
     }
 
     function extSignTx(MsgExtSignTx.Data calldata msg_) external override returns (MsgExtSignTxResponse.Data memory) {
-        if (msg_.txID.length != 32) {
-            revert InvalidTxIDLength();
-        }
-
-        bytes32 txID = abi.decode(msg_.txID, (bytes32));
+        bytes32 txID = _decodeTxID(msg_.txID);
 
         _verifySignatures(txID, msg_.signers);
 
@@ -74,11 +66,7 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
         override
         returns (QueryTxAuthStateResponse.Data memory resp)
     {
-        if (req_.txID.length != 32) {
-            revert InvalidTxIDLength();
-        }
-
-        bytes32 txID = abi.decode(req_.txID, (bytes32));
+        bytes32 txID = _decodeTxID(req_.txID);
 
         CrossStore.AuthStorage storage s = _getAuthStorage();
         if (!s.authInitialized[txID]) revert IDNotFound(txID);
@@ -86,6 +74,13 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
         Account.Data[] memory remains = _getRemainingSigners(s, txID);
 
         return QueryTxAuthStateResponse.Data({tx_auth_state: TxAuthState.Data({remaining_signers: remains})});
+    }
+
+    function _decodeTxID(bytes calldata rawID) internal pure returns (bytes32) {
+        if (rawID.length != 32) {
+            revert InvalidTxIDLength();
+        }
+        return abi.decode(rawID, (bytes32));
     }
 
     function _getRemainingSigners(CrossStore.AuthStorage storage s, bytes32 txID)

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -14,7 +14,8 @@ import {
     MsgExtSignTxResponse,
     QueryTxAuthStateRequest,
     QueryTxAuthStateResponse,
-    Account
+    Account,
+    TxAuthState
 } from "../proto/cross/core/auth/Auth.sol";
 import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
 
@@ -49,15 +50,16 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
         return MsgExtSignTxResponse.Data({x: true});
     }
 
-    function txAuthState(
-        QueryTxAuthStateRequest.Data calldata /*req_*/
-    )
+    function txAuthState(QueryTxAuthStateRequest.Data calldata req_)
         external
-        view
         override
         returns (QueryTxAuthStateResponse.Data memory resp)
     {
-        revert TxAuthStateNotImplemented();
+        bytes32 txIDHash = sha256(req_.txID);
+
+        TxAuthState.Data memory state = _getAuthState(txIDHash);
+
+        return QueryTxAuthStateResponse.Data({tx_auth_state: state});
     }
 
     function _buildLocalAccounts(bytes[] calldata signerIDs) internal pure returns (Account.Data[] memory) {

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IAuthenticator} from "./IAuthenticator.sol";
 import {TxAuthManagerBase} from "./TxAuthManagerBase.sol";
 import {TxManagerBase} from "./TxManagerBase.sol";
+import {CrossStore} from "./CrossStore.sol";
 import {ICrossError} from "./ICrossError.sol";
 
 import {
@@ -19,7 +20,7 @@ import {
 } from "../proto/cross/core/auth/Auth.sol";
 import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
 
-abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, ICrossError {
+abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, CrossStore, ICrossError {
     function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
         if (msg_.signers.length != 1) {
             revert InvalidSignersLength();
@@ -61,14 +62,41 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
 
     function txAuthState(QueryTxAuthStateRequest.Data calldata req_)
         external
+        view
         override
         returns (QueryTxAuthStateResponse.Data memory resp)
     {
         bytes32 txIDHash = sha256(req_.txID);
 
-        TxAuthState.Data memory state = _getAuthState(txIDHash);
+        CrossStore.AuthStorage storage s = _getAuthStorage();
+        if (!s.authInitialized[txIDHash]) revert IDNotFound(txIDHash);
 
-        return QueryTxAuthStateResponse.Data({tx_auth_state: state});
+        Account.Data[] memory remains = _getRemainingSigners(s, txIDHash);
+
+        return QueryTxAuthStateResponse.Data({tx_auth_state: TxAuthState.Data({remaining_signers: remains})});
+    }
+
+    function _getRemainingSigners(CrossStore.AuthStorage storage s, bytes32 txID)
+        internal
+        view
+        returns (Account.Data[] memory out)
+    {
+        uint256 total = s.requiredAccounts[txID].length;
+        uint256 need = s.remainingCount[txID];
+        out = new Account.Data[](need);
+        uint256 p = 0;
+        for (uint256 i = 0; i < total; ++i) {
+            Account.Data memory acc = s.requiredAccounts[txID][i];
+            if (s.remaining[txID][_accountKey(acc)]) {
+                out[p] = acc;
+                ++p;
+                if (p == need) break;
+            }
+        }
+    }
+
+    function _accountKey(Account.Data memory a) internal pure returns (bytes32) {
+        return keccak256(abi.encode(a.id, a.auth_type));
     }
 
     function _buildLocalAccounts(bytes[] calldata signerIDs) internal pure returns (Account.Data[] memory) {

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -22,6 +22,12 @@ import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/pr
 
 abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, CrossStore, ICrossError {
     function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
+        if (msg_.txID.length != 32) {
+            revert InvalidTxIDLength();
+        }
+
+        bytes32 txID = abi.decode(msg_.txID, (bytes32));
+
         if (msg_.signers.length != 1) {
             revert InvalidSignersLength();
         }
@@ -33,29 +39,31 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
 
         Account.Data[] memory accounts = _buildLocalAccounts(msg_.signers);
 
-        bytes32 txIDHash = sha256(msg_.txID);
-
-        bool completed = _sign(txIDHash, accounts);
+        bool completed = _sign(txID, accounts);
         if (completed) {
-            _runTxIfCompleted(txIDHash);
+            _runTxIfCompleted(txID);
         }
 
-        emit TxSigned(msg.sender, txIDHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+        emit TxSigned(msg.sender, txID, AuthType.AuthMode.AUTH_MODE_LOCAL);
 
         return MsgSignTxResponse.Data({tx_auth_completed: completed, log: ""});
     }
 
     function extSignTx(MsgExtSignTx.Data calldata msg_) external override returns (MsgExtSignTxResponse.Data memory) {
-        bytes32 txIDHash = sha256(msg_.txID);
-
-        _verifySignatures(txIDHash, msg_.signers);
-
-        bool completed = _sign(txIDHash, msg_.signers);
-        if (completed) {
-            _runTxIfCompleted(txIDHash);
+        if (msg_.txID.length != 32) {
+            revert InvalidTxIDLength();
         }
 
-        emit TxSigned(msg.sender, txIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+        bytes32 txID = abi.decode(msg_.txID, (bytes32));
+
+        _verifySignatures(txID, msg_.signers);
+
+        bool completed = _sign(txID, msg_.signers);
+        if (completed) {
+            _runTxIfCompleted(txID);
+        }
+
+        emit TxSigned(msg.sender, txID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         return MsgExtSignTxResponse.Data({x: true});
     }
@@ -66,12 +74,16 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
         override
         returns (QueryTxAuthStateResponse.Data memory resp)
     {
-        bytes32 txIDHash = sha256(req_.txID);
+        if (req_.txID.length != 32) {
+            revert InvalidTxIDLength();
+        }
+
+        bytes32 txID = abi.decode(req_.txID, (bytes32));
 
         CrossStore.AuthStorage storage s = _getAuthStorage();
-        if (!s.authInitialized[txIDHash]) revert IDNotFound(txIDHash);
+        if (!s.authInitialized[txID]) revert IDNotFound(txID);
 
-        Account.Data[] memory remains = _getRemainingSigners(s, txIDHash);
+        Account.Data[] memory remains = _getRemainingSigners(s, txID);
 
         return QueryTxAuthStateResponse.Data({tx_auth_state: TxAuthState.Data({remaining_signers: remains})});
     }

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.20;
 import {IAuthenticator} from "./IAuthenticator.sol";
 import {TxAuthManagerBase} from "./TxAuthManagerBase.sol";
 import {TxManagerBase} from "./TxManagerBase.sol";
-import {CrossStore} from "./CrossStore.sol";
 import {ICrossError} from "./ICrossError.sol";
 
 import {
@@ -20,7 +19,7 @@ import {
 } from "../proto/cross/core/auth/Auth.sol";
 import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
 
-abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, CrossStore, ICrossError {
+abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, ICrossError {
     function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
         if (msg_.signers.length != 1) {
             revert InvalidSignersLength();
@@ -62,41 +61,14 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
 
     function txAuthState(QueryTxAuthStateRequest.Data calldata req_)
         external
-        view
         override
         returns (QueryTxAuthStateResponse.Data memory resp)
     {
         bytes32 txIDHash = sha256(req_.txID);
 
-        CrossStore.AuthStorage storage s = _getAuthStorage();
-        if (!s.authInitialized[txIDHash]) revert IDNotFound(txIDHash);
+        TxAuthState.Data memory state = _getAuthState(txIDHash);
 
-        Account.Data[] memory remains = _getRemainingSigners(s, txIDHash);
-
-        return QueryTxAuthStateResponse.Data({tx_auth_state: TxAuthState.Data({remaining_signers: remains})});
-    }
-
-    function _getRemainingSigners(CrossStore.AuthStorage storage s, bytes32 txID)
-        internal
-        view
-        returns (Account.Data[] memory out)
-    {
-        uint256 total = s.requiredAccounts[txID].length;
-        uint256 need = s.remainingCount[txID];
-        out = new Account.Data[](need);
-        uint256 p = 0;
-        for (uint256 i = 0; i < total; ++i) {
-            Account.Data memory acc = s.requiredAccounts[txID][i];
-            if (s.remaining[txID][_accountKey(acc)]) {
-                out[p] = acc;
-                ++p;
-                if (p == need) break;
-            }
-        }
-    }
-
-    function _accountKey(Account.Data memory a) internal pure returns (bytes32) {
-        return keccak256(abi.encode(a.id, a.auth_type));
+        return QueryTxAuthStateResponse.Data({tx_auth_state: state});
     }
 
     function _buildLocalAccounts(bytes[] calldata signerIDs) internal pure returns (Account.Data[] memory) {

--- a/src/core/CrossModule.sol
+++ b/src/core/CrossModule.sol
@@ -16,12 +16,14 @@ import "./IBCKeeper.sol";
 import {Initiator} from "./Initiator.sol";
 import {Authenticator} from "./Authenticator.sol";
 import {DelegatedLogicHandler} from "./DelegatedLogicHandler.sol";
+import {CrossStore} from "./CrossStore.sol";
 
 abstract contract CrossModule is
     AccessControl,
     IIBCModule,
     IBCKeeper,
     PacketHandler,
+    CrossStore,
     Initiator,
     Authenticator,
     DelegatedLogicHandler

--- a/src/core/CrossModule.sol
+++ b/src/core/CrossModule.sol
@@ -16,14 +16,12 @@ import "./IBCKeeper.sol";
 import {Initiator} from "./Initiator.sol";
 import {Authenticator} from "./Authenticator.sol";
 import {DelegatedLogicHandler} from "./DelegatedLogicHandler.sol";
-import {CrossStore} from "./CrossStore.sol";
 
 abstract contract CrossModule is
     AccessControl,
     IIBCModule,
     IBCKeeper,
     PacketHandler,
-    CrossStore,
     Initiator,
     Authenticator,
     DelegatedLogicHandler

--- a/src/core/DelegatedLogicHandler.sol
+++ b/src/core/DelegatedLogicHandler.sol
@@ -15,6 +15,13 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
     address public immutable TX_AUTH_MANAGER;
     address public immutable TX_MANAGER;
 
+    modifier onlySelf() {
+        if (msg.sender != address(this)) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        _;
+    }
+
     constructor(address txAuthManager_, address txManager_) {
         TX_AUTH_MANAGER = txAuthManager_;
         TX_MANAGER = txManager_;
@@ -42,8 +49,7 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
      * will be THIS contract address, NOT the original caller.
      * Do not rely on `msg.sender` for access control in the implementation logic.
      */
-    function __isCompletedAuth(bytes32 txID) external returns (bool) {
-        if (msg.sender != address(this)) revert UnauthorizedCaller(msg.sender);
+    function __isCompletedAuth(bytes32 txID) external onlySelf returns (bool) {
         bytes memory ret =
             _delegateWithData(TX_AUTH_MANAGER, abi.encodeWithSelector(ITxAuthManager.isCompletedAuth.selector, txID));
         return abi.decode(ret, (bool));
@@ -61,8 +67,7 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
      * will be THIS contract address, NOT the original caller.
      * Do not rely on `msg.sender` for access control in the implementation logic.
      */
-    function __getAuthState(bytes32 txID) external returns (TxAuthState.Data memory) {
-        if (msg.sender != address(this)) revert UnauthorizedCaller(msg.sender);
+    function __getAuthState(bytes32 txID) external onlySelf returns (TxAuthState.Data memory) {
         bytes memory ret =
             _delegateWithData(TX_AUTH_MANAGER, abi.encodeWithSelector(ITxAuthManager.getAuthState.selector, txID));
         return abi.decode(ret, (TxAuthState.Data));
@@ -94,8 +99,7 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
      * will be THIS contract address, NOT the original caller.
      * Do not rely on `msg.sender` for access control in the implementation logic.
      */
-    function __isTxRecorded(bytes32 txID) external returns (bool) {
-        if (msg.sender != address(this)) revert UnauthorizedCaller(msg.sender);
+    function __isTxRecorded(bytes32 txID) external onlySelf returns (bool) {
         bytes memory ret = _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.isTxRecorded.selector, txID));
         return abi.decode(ret, (bool));
     }

--- a/src/core/DelegatedLogicHandler.sol
+++ b/src/core/DelegatedLogicHandler.sol
@@ -36,6 +36,7 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
     }
 
     function __isCompletedAuth(bytes32 txID) external returns (bool) {
+        if (msg.sender != address(this)) revert UnauthorizedCaller(msg.sender);
         bytes memory ret =
             _delegateWithData(TX_AUTH_MANAGER, abi.encodeWithSelector(ITxAuthManager.isCompletedAuth.selector, txID));
         return abi.decode(ret, (bool));
@@ -47,6 +48,7 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
     }
 
     function __getAuthState(bytes32 txID) external returns (TxAuthState.Data memory) {
+        if (msg.sender != address(this)) revert UnauthorizedCaller(msg.sender);
         bytes memory ret =
             _delegateWithData(TX_AUTH_MANAGER, abi.encodeWithSelector(ITxAuthManager.getAuthState.selector, txID));
         return abi.decode(ret, (TxAuthState.Data));
@@ -72,6 +74,7 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
     }
 
     function __isTxRecorded(bytes32 txID) external returns (bool) {
+        if (msg.sender != address(this)) revert UnauthorizedCaller(msg.sender);
         bytes memory ret = _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.isTxRecorded.selector, txID));
         return abi.decode(ret, (bool));
     }

--- a/src/core/DelegatedLogicHandler.sol
+++ b/src/core/DelegatedLogicHandler.sol
@@ -30,13 +30,23 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
         return abi.decode(ret, (bool));
     }
 
-    function _isCompletedAuth(bytes32 txID) internal virtual override returns (bool) {
+    function _isCompletedAuth(bytes32 txID) internal view virtual override returns (bool) {
+        bytes memory ret = _staticCallSelf(abi.encodeWithSelector(this.__isCompletedAuth.selector, txID));
+        return abi.decode(ret, (bool));
+    }
+
+    function __isCompletedAuth(bytes32 txID) external returns (bool) {
         bytes memory ret =
             _delegateWithData(TX_AUTH_MANAGER, abi.encodeWithSelector(ITxAuthManager.isCompletedAuth.selector, txID));
         return abi.decode(ret, (bool));
     }
 
-    function _getAuthState(bytes32 txID) internal virtual override returns (TxAuthState.Data memory) {
+    function _getAuthState(bytes32 txID) internal view virtual override returns (TxAuthState.Data memory) {
+        bytes memory ret = _staticCallSelf(abi.encodeWithSelector(this.__getAuthState.selector, txID));
+        return abi.decode(ret, (TxAuthState.Data));
+    }
+
+    function __getAuthState(bytes32 txID) external returns (TxAuthState.Data memory) {
         bytes memory ret =
             _delegateWithData(TX_AUTH_MANAGER, abi.encodeWithSelector(ITxAuthManager.getAuthState.selector, txID));
         return abi.decode(ret, (TxAuthState.Data));
@@ -56,7 +66,12 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
         _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.runTxIfCompleted.selector, txID));
     }
 
-    function _isTxRecorded(bytes32 txID) internal virtual override returns (bool) {
+    function _isTxRecorded(bytes32 txID) internal view virtual override returns (bool) {
+        bytes memory ret = _staticCallSelf(abi.encodeWithSelector(this.__isTxRecorded.selector, txID));
+        return abi.decode(ret, (bool));
+    }
+
+    function __isTxRecorded(bytes32 txID) external returns (bool) {
         bytes memory ret = _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.isTxRecorded.selector, txID));
         return abi.decode(ret, (bool));
     }
@@ -73,6 +88,23 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
             } else {
                 // no revert data from callee (e.g. out-of-gas in callee or explicit revert() without reason)
                 revert DelegateCallFailed(impl);
+            }
+        }
+        return returndata;
+    }
+
+    function _staticCallSelf(bytes memory callData) internal view returns (bytes memory) {
+        (bool success, bytes memory returndata) = address(this).staticcall(callData);
+        if (!success) {
+            if (returndata.length > 0) {
+                // bubble up the revert reason from the callee
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                // no revert data from callee (e.g. out-of-gas in callee or explicit revert() without reason)
+                revert StaticCallFailed();
             }
         }
         return returndata;

--- a/src/core/DelegatedLogicHandler.sol
+++ b/src/core/DelegatedLogicHandler.sol
@@ -35,6 +35,13 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
         return abi.decode(ret, (bool));
     }
 
+    /**
+     * @dev Internal function called via staticcall to read state via delegatecall.
+     * * NOTE: Since this function is called via `address(this).staticcall`,
+     * the `msg.sender` inside the delegated implementation (TxAuthManager)
+     * will be THIS contract address, NOT the original caller.
+     * Do not rely on `msg.sender` for access control in the implementation logic.
+     */
     function __isCompletedAuth(bytes32 txID) external returns (bool) {
         if (msg.sender != address(this)) revert UnauthorizedCaller(msg.sender);
         bytes memory ret =
@@ -47,6 +54,13 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
         return abi.decode(ret, (TxAuthState.Data));
     }
 
+    /**
+     * @dev Internal function called via staticcall to read state via delegatecall.
+     * * NOTE: Since this function is called via `address(this).staticcall`,
+     * the `msg.sender` inside the delegated implementation (TxAuthManager)
+     * will be THIS contract address, NOT the original caller.
+     * Do not rely on `msg.sender` for access control in the implementation logic.
+     */
     function __getAuthState(bytes32 txID) external returns (TxAuthState.Data memory) {
         if (msg.sender != address(this)) revert UnauthorizedCaller(msg.sender);
         bytes memory ret =
@@ -73,6 +87,13 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, ICr
         return abi.decode(ret, (bool));
     }
 
+    /**
+     * @dev Internal function called via staticcall to read state via delegatecall.
+     * * NOTE: Since this function is called via `address(this).staticcall`,
+     * the `msg.sender` inside the delegated implementation (TxManager)
+     * will be THIS contract address, NOT the original caller.
+     * Do not rely on `msg.sender` for access control in the implementation logic.
+     */
     function __isTxRecorded(bytes32 txID) external returns (bool) {
         if (msg.sender != address(this)) revert UnauthorizedCaller(msg.sender);
         bytes memory ret = _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.isTxRecorded.selector, txID));

--- a/src/core/IAuthenticator.sol
+++ b/src/core/IAuthenticator.sol
@@ -25,6 +25,5 @@ interface IAuthenticator {
 
     function txAuthState(QueryTxAuthStateRequest.Data calldata req_)
         external
-        view
         returns (QueryTxAuthStateResponse.Data memory);
 }

--- a/src/core/IAuthenticator.sol
+++ b/src/core/IAuthenticator.sol
@@ -25,5 +25,6 @@ interface IAuthenticator {
 
     function txAuthState(QueryTxAuthStateRequest.Data calldata req_)
         external
+        view
         returns (QueryTxAuthStateResponse.Data memory);
 }

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 interface ICrossError {
     error DelegateCallFailed(address target);
+    error StaticCallFailed();
     error UnexpectedChainID(bytes32 expectedHash, bytes32 gotHash);
     error MessageTimeoutHeight(uint256 blockNumber, uint64 timeoutVersionHeight);
     error MessageTimeoutTimestamp(uint256 blockTimestamp, uint64 timeoutTimestamp);

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 interface ICrossError {
     error DelegateCallFailed(address target);
     error StaticCallFailed();
+    error UnauthorizedCaller(address caller);
     error UnexpectedChainID(bytes32 expectedHash, bytes32 gotHash);
     error MessageTimeoutHeight(uint256 blockNumber, uint64 timeoutVersionHeight);
     error MessageTimeoutTimestamp(uint256 blockTimestamp, uint64 timeoutTimestamp);

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -9,6 +9,7 @@ interface ICrossError {
     error TxIDAlreadyExists(bytes32 txIDHash);
     error AuthStateAlreadyInitialized(bytes32 txID);
     error IDNotFound(bytes32 txID);
+    error InvalidTxIDLength();
     error InvalidSignersLength();
     error SignerMustEqualSender();
     error AuthAlreadyCompleted(bytes32 txID);

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -24,7 +24,6 @@ interface ICrossError {
     error VerifierReturnedFalse(bytes32 txIDHash, string typeUrl);
     error TooManySigners(uint256 got, uint256 maxAllowed);
     error TxRunNotImplemented();
-    error TxAuthStateNotImplemented();
     error ModuleAlreadyInitialized();
     error ModuleNotInitialized();
     error PayloadDecodeFailed();

--- a/src/core/ITxAuthManager.sol
+++ b/src/core/ITxAuthManager.sol
@@ -5,8 +5,8 @@ import {Account, TxAuthState} from "../proto/cross/core/auth/Auth.sol";
 
 interface ITxAuthManager {
     function initAuthState(bytes32 txID, Account.Data[] calldata signers) external;
-    function isCompletedAuth(bytes32 txID) external returns (bool);
+    function isCompletedAuth(bytes32 txID) external view returns (bool);
     function sign(bytes32 txID, Account.Data[] calldata signers) external returns (bool);
-    function getAuthState(bytes32 txID) external returns (TxAuthState.Data memory);
+    function getAuthState(bytes32 txID) external view returns (TxAuthState.Data memory);
     function verifySignatures(bytes32 txIDHash, Account.Data[] calldata signers) external;
 }

--- a/src/core/ITxManager.sol
+++ b/src/core/ITxManager.sol
@@ -6,5 +6,5 @@ import {MsgInitiateTx} from "../proto/cross/core/initiator/Initiator.sol";
 interface ITxManager {
     function createTx(bytes32 txID, MsgInitiateTx.Data calldata src) external;
     function runTxIfCompleted(bytes32 txID) external;
-    function isTxRecorded(bytes32 txID) external returns (bool);
+    function isTxRecorded(bytes32 txID) external view returns (bool);
 }

--- a/src/core/TxAuthManager.sol
+++ b/src/core/TxAuthManager.sol
@@ -31,7 +31,7 @@ contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossE
         _initAuthState(txID, signers);
     }
 
-    function isCompletedAuth(bytes32 txID) external override returns (bool) {
+    function isCompletedAuth(bytes32 txID) external view override returns (bool) {
         return _isCompletedAuth(txID);
     }
 
@@ -39,7 +39,7 @@ contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossE
         return _sign(txID, signers);
     }
 
-    function getAuthState(bytes32 txID) external override returns (TxAuthState.Data memory) {
+    function getAuthState(bytes32 txID) external view override returns (TxAuthState.Data memory) {
         return _getAuthState(txID);
     }
 
@@ -54,7 +54,7 @@ contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossE
         s.authInitialized[txID] = true;
     }
 
-    function _isCompletedAuth(bytes32 txID) internal virtual override returns (bool) {
+    function _isCompletedAuth(bytes32 txID) internal view virtual override returns (bool) {
         CrossStore.AuthStorage storage s = _getAuthStorage();
         if (!s.authInitialized[txID]) revert IDNotFound(txID);
         return s.remainingCount[txID] == 0;
@@ -76,7 +76,7 @@ contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossE
         return s.remainingCount[txID] == 0;
     }
 
-    function _getAuthState(bytes32 txID) internal virtual override returns (TxAuthState.Data memory) {
+    function _getAuthState(bytes32 txID) internal view virtual override returns (TxAuthState.Data memory) {
         CrossStore.AuthStorage storage s = _getAuthStorage();
         if (!s.authInitialized[txID]) revert IDNotFound(txID);
         Account.Data[] memory remains = _getRemainingSigners(s, txID);

--- a/src/core/TxAuthManagerBase.sol
+++ b/src/core/TxAuthManagerBase.sol
@@ -5,8 +5,8 @@ import {Account, TxAuthState} from "../proto/cross/core/auth/Auth.sol";
 
 abstract contract TxAuthManagerBase {
     function _initAuthState(bytes32 txID, Account.Data[] memory signers) internal virtual;
-    function _isCompletedAuth(bytes32 txID) internal virtual returns (bool);
+    function _isCompletedAuth(bytes32 txID) internal view virtual returns (bool);
     function _sign(bytes32 txID, Account.Data[] memory signers) internal virtual returns (bool);
-    function _getAuthState(bytes32 txID) internal virtual returns (TxAuthState.Data memory);
+    function _getAuthState(bytes32 txID) internal view virtual returns (TxAuthState.Data memory);
     function _verifySignatures(bytes32 txIDHash, Account.Data[] calldata signers) internal virtual;
 }

--- a/src/core/TxManager.sol
+++ b/src/core/TxManager.sol
@@ -18,7 +18,7 @@ contract TxManager is TxManagerBase, TxRunner, CrossStore, ITxManager {
         _runTxIfCompleted(txID);
     }
 
-    function isTxRecorded(bytes32 txID) external override returns (bool) {
+    function isTxRecorded(bytes32 txID) external view override returns (bool) {
         return _isTxRecorded(txID);
     }
 
@@ -39,7 +39,7 @@ contract TxManager is TxManagerBase, TxRunner, CrossStore, ITxManager {
         _runTx(txID, t.txMsg[txID]);
     }
 
-    function _isTxRecorded(bytes32 txID) internal virtual override returns (bool) {
+    function _isTxRecorded(bytes32 txID) internal view virtual override returns (bool) {
         CrossStore.TxStorage storage t = _getTxStorage();
         return t.txStatus[txID] != MsgInitiateTxResponse.InitiateTxStatus.INITIATE_TX_STATUS_UNKNOWN;
     }

--- a/src/core/TxManagerBase.sol
+++ b/src/core/TxManagerBase.sol
@@ -6,5 +6,5 @@ import {MsgInitiateTx} from "../proto/cross/core/initiator/Initiator.sol";
 abstract contract TxManagerBase {
     function _createTx(bytes32 txID, MsgInitiateTx.Data calldata src) internal virtual;
     function _runTxIfCompleted(bytes32 txID) internal virtual;
-    function _isTxRecorded(bytes32 txID) internal virtual returns (bool);
+    function _isTxRecorded(bytes32 txID) internal view virtual returns (bool);
 }

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -9,6 +9,7 @@ import {TxAuthManagerBase} from "../src/core/TxAuthManagerBase.sol";
 
 import {MsgInitiateTx} from "../src/proto/cross/core/initiator/Initiator.sol";
 import {IAuthenticator} from "../src/core/IAuthenticator.sol";
+import {ICrossError} from "../src/core/ICrossError.sol";
 import {
     Account as AuthAccount,
     AuthType,
@@ -168,12 +169,13 @@ contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager
     }
 }
 
-contract AuthenticatorTest is Test {
+contract AuthenticatorTest is Test, ICrossError {
     AuthenticatorHarness private harness;
     MsgSignTx.Data private baseMsg;
-    bytes32 private txIDHash;
+    bytes32 private txID;
     MsgExtSignTx.Data private extMsg;
-    bytes32 private extTxIDHash;
+    bytes32 private extTxID;
+
     bytes private signerABytes = bytes("signerA");
     bytes private signerBBytes = bytes("signerB");
 
@@ -185,17 +187,18 @@ contract AuthenticatorTest is Test {
         bytes[] memory signers = new bytes[](1);
         signers[0] = expectedSignerId;
 
+        bytes32 rawTxID = bytes32("test-tx-id");
+        txID = rawTxID;
+
         baseMsg = MsgSignTx.Data({
-            txID: bytes("test-tx-id"),
+            txID: abi.encodePacked(rawTxID),
             signers: signers,
             timeout_height: IbcCoreClientV1Height.Data(0, 0),
             timeout_timestamp: 0
         });
 
-        txIDHash = sha256(baseMsg.txID);
-
-        bytes memory extTxID = bytes("ext-test-tx-id");
-        extTxIDHash = sha256(extTxID);
+        bytes32 rawExtTxID = bytes32("ext-test-tx-id");
+        extTxID = rawExtTxID;
 
         AuthAccount.Data[] memory extSigners = new AuthAccount.Data[](1);
         extSigners[0] = AuthAccount.Data({
@@ -206,7 +209,7 @@ contract AuthenticatorTest is Test {
             })
         });
 
-        extMsg = MsgExtSignTx.Data({txID: extTxID, signers: extSigners});
+        extMsg = MsgExtSignTx.Data({txID: abi.encodePacked(rawExtTxID), signers: extSigners});
     }
 
     function test_signTx_SucceedsAsPending() public {
@@ -215,7 +218,7 @@ contract AuthenticatorTest is Test {
         MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
         assertFalse(resp.tx_auth_completed, "response should indicate not completed");
         assertEq(resp.log, "", "log should be empty");
-        assertFalse(harness.completed(txIDHash), "Mock: auth should not be completed");
+        assertFalse(harness.completed(txID), "Mock: auth should not be completed");
         assertEq(harness.runTxCount(), 0, "Mock: runTxIfCompleted should not be called");
     }
 
@@ -223,15 +226,22 @@ contract AuthenticatorTest is Test {
         harness.setSignReturns(true);
 
         vm.expectEmit(true, true, false, true, address(harness));
-        emit IAuthenticator.TxSigned(address(this), txIDHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+        emit IAuthenticator.TxSigned(address(this), txID, AuthType.AuthMode.AUTH_MODE_LOCAL);
 
         MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
 
         assertTrue(resp.tx_auth_completed, "response should indicate completed");
         assertEq(resp.log, "", "log should be empty");
-        assertTrue(harness.completed(txIDHash), "Mock: auth should be completed");
+        assertTrue(harness.completed(txID), "Mock: auth should be completed");
         assertEq(harness.runTxCount(), 1, "Mock: runTxIfCompleted should be called once");
-        assertEq(harness.lastRunTxID(), txIDHash, "Mock: runTxIfCompleted called with correct txID");
+        assertEq(harness.lastRunTxID(), txID, "Mock: runTxIfCompleted called with correct txID");
+    }
+
+    function test_signTx_RevertsIf_TxIDLengthInvalid() public {
+        baseMsg.txID = bytes("short-id");
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.signTx(baseMsg);
     }
 
     function test_signTx_RevertsIf_SignersLengthZero() public {
@@ -262,14 +272,13 @@ contract AuthenticatorTest is Test {
 
     function test_extSignTx_SucceedsAsPending() public {
         harness.setSignReturns(false);
-
         vm.expectEmit(address(harness));
-        emit IAuthenticator.TxSigned(address(this), extTxIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+        emit IAuthenticator.TxSigned(address(this), extTxID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);
 
         assertTrue(resp.x, "response.x should be true");
-        assertFalse(harness.completed(extTxIDHash), "Mock: auth should not be completed");
+        assertFalse(harness.completed(extTxID), "Mock: auth should not be completed");
         assertEq(harness.runTxCount(), 0, "Mock: runTxIfCompleted should not be called");
     }
 
@@ -277,14 +286,21 @@ contract AuthenticatorTest is Test {
         harness.setSignReturns(true);
 
         vm.expectEmit(address(harness));
-        emit IAuthenticator.TxSigned(address(this), extTxIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+        emit IAuthenticator.TxSigned(address(this), extTxID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);
 
         assertTrue(resp.x, "response.x should be true");
-        assertTrue(harness.completed(extTxIDHash), "Mock: auth should be completed");
+        assertTrue(harness.completed(extTxID), "Mock: auth should be completed");
         assertEq(harness.runTxCount(), 1, "Mock: runTxIfCompleted should be called once");
-        assertEq(harness.lastRunTxID(), extTxIDHash, "Mock: runTxIfCompleted called with correct txID");
+        assertEq(harness.lastRunTxID(), extTxID, "Mock: runTxIfCompleted called with correct txID");
+    }
+
+    function test_extSignTx_RevertsIf_TxIDLengthInvalid() public {
+        extMsg.txID = new bytes(33);
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.extSignTx(extMsg);
     }
 
     function test_extSignTx_RevertsIfVerificationFails() public {
@@ -295,8 +311,7 @@ contract AuthenticatorTest is Test {
     }
 
     function test_txAuthState_ReturnsState() public {
-        bytes memory queryTxID = bytes("query-tx");
-        bytes32 queryTxIDHash = sha256(queryTxID);
+        bytes32 queryTxID = bytes32("query-tx");
 
         AuthAccount.Data memory signerB = AuthAccount.Data({
             id: signerBBytes,
@@ -311,10 +326,10 @@ contract AuthenticatorTest is Test {
         bool[] memory isRemaining = new bool[](1);
         isRemaining[0] = true;
 
-        harness.setupMockAuthStorage(queryTxIDHash, required, isRemaining);
+        harness.setupMockAuthStorage(queryTxID, required, isRemaining);
 
         QueryTxAuthStateRequest.Data memory req;
-        req.txID = queryTxID;
+        req.txID = abi.encodePacked(queryTxID);
 
         QueryTxAuthStateResponse.Data memory resp = harness.txAuthState(req);
 
@@ -325,6 +340,14 @@ contract AuthenticatorTest is Test {
             uint256(AuthType.AuthMode.AUTH_MODE_LOCAL),
             "Remaining signer auth mode mismatch"
         );
+    }
+
+    function test_txAuthState_RevertsIf_TxIDLengthInvalid() public {
+        QueryTxAuthStateRequest.Data memory req;
+        req.txID = "";
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.txAuthState(req);
     }
 
     function test_accountKey_GeneratesDistinctKeys() public {

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -132,39 +132,8 @@ contract MockTxAuthManager is TxAuthManagerBase {
 }
 
 contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager {
-    function exposed_accountKey(AuthAccount.Data memory a) public pure returns (bytes32) {
-        return _accountKey(a);
-    }
-
-    function exposed_getRemainingSigners(bytes32 txID) public view returns (AuthAccount.Data[] memory out) {
-        CrossStore.AuthStorage storage s = _getAuthStorage();
-        return _getRemainingSigners(s, txID);
-    }
-
     function exposed_buildLocalAccounts(bytes[] calldata signerIDs) public pure returns (AuthAccount.Data[] memory) {
         return _buildLocalAccounts(signerIDs);
-    }
-
-    function setupMockAuthStorage(bytes32 txID, AuthAccount.Data[] memory required, bool[] memory isRemaining) public {
-        require(required.length == isRemaining.length, "Harness: length mismatch");
-
-        CrossStore.AuthStorage storage s = _getAuthStorage();
-
-        s.authInitialized[txID] = true;
-
-        delete s.requiredAccounts[txID];
-        s.remainingCount[txID] = 0;
-
-        for (uint256 i = 0; i < required.length; ++i) {
-            s.requiredAccounts[txID].push(required[i]);
-
-            bytes32 key = _accountKey(required[i]);
-            s.remaining[txID][key] = isRemaining[i];
-
-            if (isRemaining[i]) {
-                ++s.remainingCount[txID];
-            }
-        }
     }
 }
 
@@ -296,22 +265,17 @@ contract AuthenticatorTest is Test {
 
     function test_txAuthState_ReturnsState() public {
         bytes memory queryTxID = bytes("query-tx");
-        bytes32 queryTxIDHash = sha256(queryTxID);
 
-        AuthAccount.Data memory signerB = AuthAccount.Data({
+        AuthAccount.Data[] memory remainingSigners = new AuthAccount.Data[](1);
+        remainingSigners[0] = AuthAccount.Data({
             id: signerBBytes,
             auth_type: AuthType.Data({
                 mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: GoogleProtobufAny.Data({type_url: "", value: ""})
             })
         });
+        TxAuthState.Data memory expectedState = TxAuthState.Data({remaining_signers: remainingSigners});
 
-        AuthAccount.Data[] memory required = new AuthAccount.Data[](1);
-        required[0] = signerB;
-
-        bool[] memory isRemaining = new bool[](1);
-        isRemaining[0] = true;
-
-        harness.setupMockAuthStorage(queryTxIDHash, required, isRemaining);
+        harness.setMockAuthState(expectedState);
 
         QueryTxAuthStateRequest.Data memory req;
         req.txID = queryTxID;
@@ -325,99 +289,6 @@ contract AuthenticatorTest is Test {
             uint256(AuthType.AuthMode.AUTH_MODE_LOCAL),
             "Remaining signer auth mode mismatch"
         );
-    }
-
-    function test_accountKey_GeneratesDistinctKeys() public {
-        AuthAccount.Data memory acc1 = AuthAccount.Data({
-            id: signerABytes,
-            auth_type: AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: GoogleProtobufAny.Data("", "")})
-        });
-        AuthAccount.Data memory acc2 = AuthAccount.Data({
-            id: signerBBytes,
-            auth_type: AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: GoogleProtobufAny.Data("", "")})
-        });
-        AuthAccount.Data memory acc3 = AuthAccount.Data({
-            id: signerABytes,
-            auth_type: AuthType.Data({
-                mode: AuthType.AuthMode.AUTH_MODE_EXTENSION, option: GoogleProtobufAny.Data("", "")
-            })
-        });
-
-        bytes32 key1 = harness.exposed_accountKey(acc1);
-        bytes32 key2 = harness.exposed_accountKey(acc2);
-        bytes32 key3 = harness.exposed_accountKey(acc3);
-        assertNotEq(key1, key2, "Keys should be different for different IDs");
-        assertNotEq(key1, key3, "Keys should be different for different AuthTypes");
-    }
-
-    function test_getRemainingSigners_AllRemaining() public {
-        bytes32 testTxID = bytes32(uint256(111));
-
-        AuthAccount.Data[] memory signers = new AuthAccount.Data[](2);
-        signers[0] = AuthAccount.Data(
-            signerABytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
-        );
-        signers[1] = AuthAccount.Data(
-            signerBBytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
-        );
-
-        bool[] memory isRemaining = new bool[](2);
-        isRemaining[0] = true;
-        isRemaining[1] = true;
-
-        harness.setupMockAuthStorage(testTxID, signers, isRemaining);
-
-        AuthAccount.Data[] memory result = harness.exposed_getRemainingSigners(testTxID);
-
-        assertEq(result.length, 2, "Should return all signers");
-        assertEq(result[0].id, signerABytes, "First signer mismatch");
-        assertEq(result[1].id, signerBBytes, "Second signer mismatch");
-    }
-
-    function test_getRemainingSigners_PartialRemaining() public {
-        bytes32 testTxID = bytes32(uint256(222));
-
-        AuthAccount.Data[] memory signers = new AuthAccount.Data[](3);
-        signers[0] = AuthAccount.Data(
-            signerABytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
-        );
-        signers[1] = AuthAccount.Data(
-            signerBBytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
-        );
-        signers[2] = AuthAccount.Data(
-            bytes("signerC"), AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
-        );
-
-        bool[] memory isRemaining = new bool[](3);
-        isRemaining[0] = true; // A
-        isRemaining[1] = false; // B (Signed)
-        isRemaining[2] = true; // C
-
-        harness.setupMockAuthStorage(testTxID, signers, isRemaining);
-
-        AuthAccount.Data[] memory result = harness.exposed_getRemainingSigners(testTxID);
-
-        assertEq(result.length, 2, "Should return 2 remaining signers");
-        assertEq(result[0].id, signerABytes, "First remaining should be A");
-        assertEq(result[1].id, bytes("signerC"), "Second remaining should be C");
-    }
-
-    function test_getRemainingSigners_NoneRemaining() public {
-        bytes32 testTxID = bytes32(uint256(333));
-
-        AuthAccount.Data[] memory signers = new AuthAccount.Data[](1);
-        signers[0] = AuthAccount.Data(
-            signerABytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
-        );
-
-        bool[] memory isRemaining = new bool[](1);
-        isRemaining[0] = false;
-
-        harness.setupMockAuthStorage(testTxID, signers, isRemaining);
-
-        AuthAccount.Data[] memory result = harness.exposed_getRemainingSigners(testTxID);
-
-        assertEq(result.length, 0, "Should return empty array when no signers remain");
     }
 
     function test_buildLocalAccounts_BuildsCorrectly() public {

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -132,8 +132,39 @@ contract MockTxAuthManager is TxAuthManagerBase {
 }
 
 contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager {
+    function exposed_accountKey(AuthAccount.Data memory a) public pure returns (bytes32) {
+        return _accountKey(a);
+    }
+
+    function exposed_getRemainingSigners(bytes32 txID) public view returns (AuthAccount.Data[] memory out) {
+        CrossStore.AuthStorage storage s = _getAuthStorage();
+        return _getRemainingSigners(s, txID);
+    }
+
     function exposed_buildLocalAccounts(bytes[] calldata signerIDs) public pure returns (AuthAccount.Data[] memory) {
         return _buildLocalAccounts(signerIDs);
+    }
+
+    function setupMockAuthStorage(bytes32 txID, AuthAccount.Data[] memory required, bool[] memory isRemaining) public {
+        require(required.length == isRemaining.length, "Harness: length mismatch");
+
+        CrossStore.AuthStorage storage s = _getAuthStorage();
+
+        s.authInitialized[txID] = true;
+
+        delete s.requiredAccounts[txID];
+        s.remainingCount[txID] = 0;
+
+        for (uint256 i = 0; i < required.length; ++i) {
+            s.requiredAccounts[txID].push(required[i]);
+
+            bytes32 key = _accountKey(required[i]);
+            s.remaining[txID][key] = isRemaining[i];
+
+            if (isRemaining[i]) {
+                ++s.remainingCount[txID];
+            }
+        }
     }
 }
 
@@ -265,17 +296,22 @@ contract AuthenticatorTest is Test {
 
     function test_txAuthState_ReturnsState() public {
         bytes memory queryTxID = bytes("query-tx");
+        bytes32 queryTxIDHash = sha256(queryTxID);
 
-        AuthAccount.Data[] memory remainingSigners = new AuthAccount.Data[](1);
-        remainingSigners[0] = AuthAccount.Data({
+        AuthAccount.Data memory signerB = AuthAccount.Data({
             id: signerBBytes,
             auth_type: AuthType.Data({
                 mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: GoogleProtobufAny.Data({type_url: "", value: ""})
             })
         });
-        TxAuthState.Data memory expectedState = TxAuthState.Data({remaining_signers: remainingSigners});
 
-        harness.setMockAuthState(expectedState);
+        AuthAccount.Data[] memory required = new AuthAccount.Data[](1);
+        required[0] = signerB;
+
+        bool[] memory isRemaining = new bool[](1);
+        isRemaining[0] = true;
+
+        harness.setupMockAuthStorage(queryTxIDHash, required, isRemaining);
 
         QueryTxAuthStateRequest.Data memory req;
         req.txID = queryTxID;
@@ -289,6 +325,99 @@ contract AuthenticatorTest is Test {
             uint256(AuthType.AuthMode.AUTH_MODE_LOCAL),
             "Remaining signer auth mode mismatch"
         );
+    }
+
+    function test_accountKey_GeneratesDistinctKeys() public {
+        AuthAccount.Data memory acc1 = AuthAccount.Data({
+            id: signerABytes,
+            auth_type: AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: GoogleProtobufAny.Data("", "")})
+        });
+        AuthAccount.Data memory acc2 = AuthAccount.Data({
+            id: signerBBytes,
+            auth_type: AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: GoogleProtobufAny.Data("", "")})
+        });
+        AuthAccount.Data memory acc3 = AuthAccount.Data({
+            id: signerABytes,
+            auth_type: AuthType.Data({
+                mode: AuthType.AuthMode.AUTH_MODE_EXTENSION, option: GoogleProtobufAny.Data("", "")
+            })
+        });
+
+        bytes32 key1 = harness.exposed_accountKey(acc1);
+        bytes32 key2 = harness.exposed_accountKey(acc2);
+        bytes32 key3 = harness.exposed_accountKey(acc3);
+        assertNotEq(key1, key2, "Keys should be different for different IDs");
+        assertNotEq(key1, key3, "Keys should be different for different AuthTypes");
+    }
+
+    function test_getRemainingSigners_AllRemaining() public {
+        bytes32 testTxID = bytes32(uint256(111));
+
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](2);
+        signers[0] = AuthAccount.Data(
+            signerABytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
+        );
+        signers[1] = AuthAccount.Data(
+            signerBBytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
+        );
+
+        bool[] memory isRemaining = new bool[](2);
+        isRemaining[0] = true;
+        isRemaining[1] = true;
+
+        harness.setupMockAuthStorage(testTxID, signers, isRemaining);
+
+        AuthAccount.Data[] memory result = harness.exposed_getRemainingSigners(testTxID);
+
+        assertEq(result.length, 2, "Should return all signers");
+        assertEq(result[0].id, signerABytes, "First signer mismatch");
+        assertEq(result[1].id, signerBBytes, "Second signer mismatch");
+    }
+
+    function test_getRemainingSigners_PartialRemaining() public {
+        bytes32 testTxID = bytes32(uint256(222));
+
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](3);
+        signers[0] = AuthAccount.Data(
+            signerABytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
+        );
+        signers[1] = AuthAccount.Data(
+            signerBBytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
+        );
+        signers[2] = AuthAccount.Data(
+            bytes("signerC"), AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
+        );
+
+        bool[] memory isRemaining = new bool[](3);
+        isRemaining[0] = true; // A
+        isRemaining[1] = false; // B (Signed)
+        isRemaining[2] = true; // C
+
+        harness.setupMockAuthStorage(testTxID, signers, isRemaining);
+
+        AuthAccount.Data[] memory result = harness.exposed_getRemainingSigners(testTxID);
+
+        assertEq(result.length, 2, "Should return 2 remaining signers");
+        assertEq(result[0].id, signerABytes, "First remaining should be A");
+        assertEq(result[1].id, bytes("signerC"), "Second remaining should be C");
+    }
+
+    function test_getRemainingSigners_NoneRemaining() public {
+        bytes32 testTxID = bytes32(uint256(333));
+
+        AuthAccount.Data[] memory signers = new AuthAccount.Data[](1);
+        signers[0] = AuthAccount.Data(
+            signerABytes, AuthType.Data(AuthType.AuthMode.AUTH_MODE_LOCAL, GoogleProtobufAny.Data("", ""))
+        );
+
+        bool[] memory isRemaining = new bool[](1);
+        isRemaining[0] = false;
+
+        harness.setupMockAuthStorage(testTxID, signers, isRemaining);
+
+        AuthAccount.Data[] memory result = harness.exposed_getRemainingSigners(testTxID);
+
+        assertEq(result.length, 0, "Should return empty array when no signers remain");
     }
 
     function test_buildLocalAccounts_BuildsCorrectly() public {

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -133,6 +133,10 @@ contract MockTxAuthManager is TxAuthManagerBase {
 }
 
 contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager {
+    function exposed_decodeTxID(bytes calldata rawID) public pure returns (bytes32) {
+        return _decodeTxID(rawID);
+    }
+
     function exposed_accountKey(AuthAccount.Data memory a) public pure returns (bytes32) {
         return _accountKey(a);
     }
@@ -303,11 +307,40 @@ contract AuthenticatorTest is Test, ICrossError {
         harness.extSignTx(extMsg);
     }
 
-    function test_extSignTx_RevertsIfVerificationFails() public {
+    function test_extSignTx_RevertsIf_VerificationFails() public {
         harness.setVerifyShouldRevert(true);
 
         vm.expectRevert(MockTxAuthManager.MockVerifyError.selector);
         harness.extSignTx(extMsg);
+    }
+
+    function test_decodeTxID_SucceedsWith32Bytes() public {
+        bytes32 expected = keccak256("valid-id");
+        bytes memory input = abi.encodePacked(expected);
+
+        bytes32 actual = harness.exposed_decodeTxID(input);
+        assertEq(actual, expected, "Should return correct bytes32 for 32-byte input");
+    }
+
+    function test_decodeTxID_RevertsIf_LengthIsZero() public {
+        bytes memory input = "";
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.exposed_decodeTxID(input);
+    }
+
+    function test_decodeTxID_RevertsIf_LengthIsShort() public {
+        bytes memory input = new bytes(31);
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.exposed_decodeTxID(input);
+    }
+
+    function test_decodeTxID_RevertsIf_LengthIsLong() public {
+        bytes memory input = new bytes(33);
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.exposed_decodeTxID(input);
     }
 
     function test_txAuthState_ReturnsState() public {

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -16,7 +16,9 @@ import {
     MsgSignTx,
     MsgSignTxResponse,
     MsgExtSignTx,
-    QueryTxAuthStateRequest
+    QueryTxAuthStateRequest,
+    QueryTxAuthStateResponse,
+    GoogleProtobufAny
 } from "../src/proto/cross/core/auth/Auth.sol";
 import {IbcCoreClientV1Height} from "../src/proto/ibc/core/client/v1/client.sol";
 
@@ -56,6 +58,7 @@ contract MockTxAuthManager is TxAuthManagerBase {
     mapping(bytes32 => bool) public completed;
     bool private _signReturns = false;
     bool private _verifyShouldRevert = false;
+    TxAuthState.Data private _mockAuthState;
 
     error MockVerifyError();
 
@@ -95,7 +98,10 @@ contract MockTxAuthManager is TxAuthManagerBase {
         }
         return _signReturns;
     }
-    function _getAuthState(bytes32) internal view virtual override returns (TxAuthState.Data memory) {}
+
+    function _getAuthState(bytes32) internal view virtual override returns (TxAuthState.Data memory) {
+        return _mockAuthState;
+    }
 
     function _verifySignatures(
         bytes32,
@@ -118,6 +124,10 @@ contract MockTxAuthManager is TxAuthManagerBase {
 
     function setVerifyShouldRevert(bool shouldRevert) public {
         _verifyShouldRevert = shouldRevert;
+    }
+
+    function setMockAuthState(TxAuthState.Data memory state) public {
+        _mockAuthState = state;
     }
 }
 
@@ -225,12 +235,32 @@ contract AuthenticatorTest is Test {
         harness.extSignTx(extMsg);
     }
 
-    function test_txAuthState_RevertsNotImplemented() public {
-        QueryTxAuthStateRequest.Data memory req;
-        req.txID = bytes("query-tx");
+    function test_txAuthState_ReturnsState() public {
+        bytes memory queryTxID = bytes("query-tx");
 
-        vm.expectRevert(ICrossError.TxAuthStateNotImplemented.selector);
-        harness.txAuthState(req);
+        AuthAccount.Data[] memory remainingSigners = new AuthAccount.Data[](1);
+        remainingSigners[0] = AuthAccount.Data({
+            id: signerBBytes,
+            auth_type: AuthType.Data({
+                mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: GoogleProtobufAny.Data({type_url: "", value: ""})
+            })
+        });
+        TxAuthState.Data memory expectedState = TxAuthState.Data({remaining_signers: remainingSigners});
+
+        harness.setMockAuthState(expectedState);
+
+        QueryTxAuthStateRequest.Data memory req;
+        req.txID = queryTxID;
+
+        QueryTxAuthStateResponse.Data memory resp = harness.txAuthState(req);
+
+        assertEq(resp.tx_auth_state.remaining_signers.length, 1, "Remaining signers length mismatch");
+        assertEq(resp.tx_auth_state.remaining_signers[0].id, signerBBytes, "Remaining signer ID mismatch");
+        assertEq(
+            uint256(resp.tx_auth_state.remaining_signers[0].auth_type.mode),
+            uint256(AuthType.AuthMode.AUTH_MODE_LOCAL),
+            "Remaining signer auth mode mismatch"
+        );
     }
 
     function test_buildLocalAccounts_BuildsCorrectly() public {

--- a/test/DelegatedLogicHandler.t.sol
+++ b/test/DelegatedLogicHandler.t.sol
@@ -43,14 +43,25 @@ contract MockTxAuthManager is ITxAuthManager, MockStore {
         return true;
     }
 
-    function isCompletedAuth(bytes32 txID) external override returns (bool) {
-        ++authStorage.callCounts[txID];
+    function isCompletedAuth(
+        bytes32 /*txID*/
+    )
+        external
+        pure
+        override
+        returns (bool)
+    {
         return true;
     }
 
-    function getAuthState(bytes32 txID) external override returns (TxAuthState.Data memory) {
-        ++authStorage.callCounts[txID];
-
+    function getAuthState(
+        bytes32 /*txID*/
+    )
+        external
+        pure
+        override
+        returns (TxAuthState.Data memory)
+    {
         AuthAccount.Data[] memory remaining = new AuthAccount.Data[](1);
         GoogleProtobufAny.Data memory emptyAny = GoogleProtobufAny.Data({type_url: "", value: ""});
         AuthType.Data memory localAuthType = AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_LOCAL, option: emptyAny});
@@ -75,8 +86,14 @@ contract MockTxManager is ITxManager, MockStore {
         txStorage.nonce[txID] = 1;
     }
 
-    function isTxRecorded(bytes32 txID) external override returns (bool) {
-        txStorage.nonce[txID] = 1;
+    function isTxRecorded(
+        bytes32 /*txID*/
+    )
+        external
+        pure
+        override
+        returns (bool)
+    {
         return true;
     }
 }
@@ -106,6 +123,8 @@ contract MockRevertEmpty {
 }
 
 contract DelegatedLogicHandlerHarness is DelegatedLogicHandler, MockStore {
+    uint256 public internalState;
+
     constructor(address txAuthManager_, address txManager_) DelegatedLogicHandler(txAuthManager_, txManager_) {}
 
     function exposed_initAuthState(bytes32 txID, AuthAccount.Data[] memory signers) public {
@@ -144,6 +163,28 @@ contract DelegatedLogicHandlerHarness is DelegatedLogicHandler, MockStore {
         return _delegateWithData(impl, data);
     }
 
+    function exposed_staticCallSelf(bytes memory callData) public view returns (bytes memory) {
+        return _staticCallSelf(callData);
+    }
+
+    function echo(uint256 val) external pure returns (uint256) {
+        return val;
+    }
+
+    function revert(string calldata reason) external pure {
+        revert(reason);
+    }
+
+    function revertEmpty() external pure {
+        assembly {
+            revert(0, 0)
+        }
+    }
+
+    function stateChange(uint256 val) external {
+        internalState = val;
+    }
+
     function readAuth_callCount(bytes32 txID) public view returns (uint256) {
         return authStorage.callCounts[txID];
     }
@@ -161,7 +202,7 @@ contract DelegatedLogicHandlerHarness is DelegatedLogicHandler, MockStore {
     }
 }
 
-contract DelegatedLogicHandlerTest is Test {
+contract DelegatedLogicHandlerTest is Test, ICrossError {
     MockTxAuthManager private mockAuth;
     MockTxManager private mockTx;
     DelegatedLogicHandlerHarness private harness;
@@ -206,16 +247,18 @@ contract DelegatedLogicHandlerTest is Test {
     }
 
     function test_isCompletedAuth_DelegatesToAuthManager() public {
+        vm.expectCall(address(mockAuth), abi.encodeWithSelector(ITxAuthManager.isCompletedAuth.selector, txID));
+
         bool result = harness.exposed_isCompletedAuth(txID);
 
         assertTrue(result, "Return value mismatch");
-        assertEq(harness.readAuth_callCount(txID), 1, "AuthManager.isCompletedAuth should be called once");
     }
 
     function test_getAuthState_DelegatesToAuthManager() public {
+        vm.expectCall(address(mockAuth), abi.encodeWithSelector(ITxAuthManager.getAuthState.selector, txID));
+
         TxAuthState.Data memory result = harness.exposed_getAuthState(txID);
 
-        assertEq(harness.readAuth_callCount(txID), 1, "AuthManager.getAuthState should be called once");
         assertEq(result.remaining_signers.length, 1, "Return value (signers length) mismatch");
         assertEq(result.remaining_signers[0].id, signers[0].id, "Return value (signer id) mismatch");
     }
@@ -249,10 +292,11 @@ contract DelegatedLogicHandlerTest is Test {
     }
 
     function test_isTxRecorded_DelegatesToTxManager() public {
+        vm.expectCall(address(mockTx), abi.encodeWithSelector(ITxManager.isTxRecorded.selector, txID));
+
         bool result = harness.exposed_isTxRecorded(txID);
 
         assertTrue(result, "Return value mismatch");
-        assertEq(harness.readTx_nonce(txID), 1, "isTxRecorded call count mismatch");
     }
 
     function test_delegateWithData_SucceedsAndReturnsData() public {
@@ -282,7 +326,40 @@ contract DelegatedLogicHandlerTest is Test {
         MockRevertEmpty reverter = new MockRevertEmpty();
         bytes memory data = abi.encodeWithSelector(reverter.revertNow.selector);
 
-        vm.expectRevert(abi.encodeWithSelector(ICrossError.DelegateCallFailed.selector, address(reverter)));
+        vm.expectRevert(abi.encodeWithSelector(DelegateCallFailed.selector, address(reverter)));
         harness.exposed_delegateWithData(address(reverter), data);
+    }
+
+    function test_staticCallSelf_Succeeds() public {
+        uint256 input = 999;
+        bytes memory callData = abi.encodeWithSelector(harness.echo.selector, input);
+
+        bytes memory ret = harness.exposed_staticCallSelf(callData);
+        uint256 decoded = abi.decode(ret, (uint256));
+
+        assertEq(decoded, input, "staticCallSelf return value mismatch");
+    }
+
+    function test_staticCallSelf_RevertsIf_TargetReverts() public {
+        string memory reason = "StaticCallError";
+        bytes memory callData = abi.encodeWithSelector(harness.revert.selector, reason);
+
+        vm.expectRevert(bytes(reason));
+        harness.exposed_staticCallSelf(callData);
+    }
+
+    function test_staticCallSelf_RevertsIf_CallFailsEmpty() public {
+        bytes memory callData = abi.encodeWithSelector(harness.revertEmpty.selector);
+
+        vm.expectRevert(StaticCallFailed.selector);
+        harness.exposed_staticCallSelf(callData);
+    }
+
+    function test_staticCallSelf_RevertsIf_OnStateChange() public {
+        uint256 newVal = 777;
+        bytes memory callData = abi.encodeWithSelector(harness.stateChange.selector, newVal);
+
+        vm.expectRevert(StaticCallFailed.selector);
+        harness.exposed_staticCallSelf(callData);
     }
 }

--- a/test/DelegatedLogicHandler.t.sol
+++ b/test/DelegatedLogicHandler.t.sol
@@ -362,4 +362,22 @@ contract DelegatedLogicHandlerTest is Test, ICrossError {
         vm.expectRevert(StaticCallFailed.selector);
         harness.exposed_staticCallSelf(callData);
     }
+
+    function test_isCompletedAuth_RevertIf_CalledExternally() public {
+        // Test: __isCompletedAuth
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, address(this)));
+        harness.__isCompletedAuth(txID);
+    }
+
+    function test_getAuthState_RevertIf_CalledExternally() public {
+        // Test: __getAuthState
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, address(this)));
+        harness.__getAuthState(txID);
+    }
+
+    function test_isTxRecorded_RevertIf_CalledExternally() public {
+        // Test: __isTxRecorded
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, address(this)));
+        harness.__isTxRecorded(txID);
+    }
 }

--- a/test/Initiator.t.sol
+++ b/test/Initiator.t.sol
@@ -69,7 +69,7 @@ contract MockTxAuthManager is TxAuthManagerBase {
         return _signReturns;
     }
 
-    function _getAuthState(bytes32) internal virtual override returns (TxAuthState.Data memory) {
+    function _getAuthState(bytes32) internal view virtual override returns (TxAuthState.Data memory) {
         revert("MockTxAuthManager._getAuthState not implemented");
     }
 


### PR DESCRIPTION
- Implemented `Authenticator.sol` and `txAuthState()`.
- Implemented unit tests for `txAuthState` and its helper functions.

## Contract Size

```
| Contract                                             | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
| CrossSimpleModule                                    | 20,144           | 21,123            | 4,432              | 28,029              |
| TxAuthManager                                        | 5,233            | 5,983             | 19,343             | 43,169              |
| TxManager                                            | 4,281            | 4,308             | 20,295             | 44,844              |

```