### PR TITLE
fix: add transaction ID length validation

### DIFF
--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -22,11 +22,7 @@ import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/pr
 
 abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, CrossStore, ICrossError {
     function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
-        if (msg_.txID.length != 32) {
-            revert InvalidTxIDLength();
-        }
-
-        bytes32 txID = abi.decode(msg_.txID, (bytes32));
+        bytes32 txID = _decodeTxID(msg_.txID);
 
         if (msg_.signers.length != 1) {
             revert InvalidSignersLength();
@@ -50,11 +46,7 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
     }
 
     function extSignTx(MsgExtSignTx.Data calldata msg_) external override returns (MsgExtSignTxResponse.Data memory) {
-        if (msg_.txID.length != 32) {
-            revert InvalidTxIDLength();
-        }
-
-        bytes32 txID = abi.decode(msg_.txID, (bytes32));
+        bytes32 txID = _decodeTxID(msg_.txID);
 
         _verifySignatures(txID, msg_.signers);
 
@@ -74,11 +66,7 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
         override
         returns (QueryTxAuthStateResponse.Data memory resp)
     {
-        if (req_.txID.length != 32) {
-            revert InvalidTxIDLength();
-        }
-
-        bytes32 txID = abi.decode(req_.txID, (bytes32));
+        bytes32 txID = _decodeTxID(req_.txID);
 
         CrossStore.AuthStorage storage s = _getAuthStorage();
         if (!s.authInitialized[txID]) revert IDNotFound(txID);
@@ -86,6 +74,13 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
         Account.Data[] memory remains = _getRemainingSigners(s, txID);
 
         return QueryTxAuthStateResponse.Data({tx_auth_state: TxAuthState.Data({remaining_signers: remains})});
+    }
+
+    function _decodeTxID(bytes calldata rawID) internal pure returns (bytes32) {
+        if (rawID.length != 32) {
+            revert InvalidTxIDLength();
+        }
+        return abi.decode(rawID, (bytes32));
     }
 
     function _getRemainingSigners(CrossStore.AuthStorage storage s, bytes32 txID)

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -22,6 +22,12 @@ import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/pr
 
 abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, CrossStore, ICrossError {
     function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
+        if (msg_.txID.length != 32) {
+            revert InvalidTxIDLength();
+        }
+
+        bytes32 txID = abi.decode(msg_.txID, (bytes32));
+
         if (msg_.signers.length != 1) {
             revert InvalidSignersLength();
         }
@@ -33,29 +39,31 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
 
         Account.Data[] memory accounts = _buildLocalAccounts(msg_.signers);
 
-        bytes32 txIDHash = sha256(msg_.txID);
-
-        bool completed = _sign(txIDHash, accounts);
+        bool completed = _sign(txID, accounts);
         if (completed) {
-            _runTxIfCompleted(txIDHash);
+            _runTxIfCompleted(txID);
         }
 
-        emit TxSigned(msg.sender, txIDHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+        emit TxSigned(msg.sender, txID, AuthType.AuthMode.AUTH_MODE_LOCAL);
 
         return MsgSignTxResponse.Data({tx_auth_completed: completed, log: ""});
     }
 
     function extSignTx(MsgExtSignTx.Data calldata msg_) external override returns (MsgExtSignTxResponse.Data memory) {
-        bytes32 txIDHash = sha256(msg_.txID);
-
-        _verifySignatures(txIDHash, msg_.signers);
-
-        bool completed = _sign(txIDHash, msg_.signers);
-        if (completed) {
-            _runTxIfCompleted(txIDHash);
+        if (msg_.txID.length != 32) {
+            revert InvalidTxIDLength();
         }
 
-        emit TxSigned(msg.sender, txIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+        bytes32 txID = abi.decode(msg_.txID, (bytes32));
+
+        _verifySignatures(txID, msg_.signers);
+
+        bool completed = _sign(txID, msg_.signers);
+        if (completed) {
+            _runTxIfCompleted(txID);
+        }
+
+        emit TxSigned(msg.sender, txID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         return MsgExtSignTxResponse.Data({x: true});
     }
@@ -66,12 +74,16 @@ abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerB
         override
         returns (QueryTxAuthStateResponse.Data memory resp)
     {
-        bytes32 txIDHash = sha256(req_.txID);
+        if (req_.txID.length != 32) {
+            revert InvalidTxIDLength();
+        }
+
+        bytes32 txID = abi.decode(req_.txID, (bytes32));
 
         CrossStore.AuthStorage storage s = _getAuthStorage();
-        if (!s.authInitialized[txIDHash]) revert IDNotFound(txIDHash);
+        if (!s.authInitialized[txID]) revert IDNotFound(txID);
 
-        Account.Data[] memory remains = _getRemainingSigners(s, txIDHash);
+        Account.Data[] memory remains = _getRemainingSigners(s, txID);
 
         return QueryTxAuthStateResponse.Data({tx_auth_state: TxAuthState.Data({remaining_signers: remains})});
     }

--- a/src/core/ICrossError.sol
+++ b/src/core/ICrossError.sol
@@ -9,6 +9,7 @@ interface ICrossError {
     error TxIDAlreadyExists(bytes32 txIDHash);
     error AuthStateAlreadyInitialized(bytes32 txID);
     error IDNotFound(bytes32 txID);
+    error InvalidTxIDLength();
     error InvalidSignersLength();
     error SignerMustEqualSender();
     error AuthAlreadyCompleted(bytes32 txID);

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -9,6 +9,7 @@ import {TxAuthManagerBase} from "../src/core/TxAuthManagerBase.sol";
 
 import {MsgInitiateTx} from "../src/proto/cross/core/initiator/Initiator.sol";
 import {IAuthenticator} from "../src/core/IAuthenticator.sol";
+import {ICrossError} from "../src/core/ICrossError.sol";
 import {
     Account as AuthAccount,
     AuthType,
@@ -168,12 +169,13 @@ contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager
     }
 }
 
-contract AuthenticatorTest is Test {
+contract AuthenticatorTest is Test, ICrossError {
     AuthenticatorHarness private harness;
     MsgSignTx.Data private baseMsg;
-    bytes32 private txIDHash;
+    bytes32 private txID;
     MsgExtSignTx.Data private extMsg;
-    bytes32 private extTxIDHash;
+    bytes32 private extTxID;
+
     bytes private signerABytes = bytes("signerA");
     bytes private signerBBytes = bytes("signerB");
 
@@ -185,17 +187,18 @@ contract AuthenticatorTest is Test {
         bytes[] memory signers = new bytes[](1);
         signers[0] = expectedSignerId;
 
+        bytes32 rawTxID = bytes32("test-tx-id");
+        txID = rawTxID;
+
         baseMsg = MsgSignTx.Data({
-            txID: bytes("test-tx-id"),
+            txID: abi.encodePacked(rawTxID),
             signers: signers,
             timeout_height: IbcCoreClientV1Height.Data(0, 0),
             timeout_timestamp: 0
         });
 
-        txIDHash = sha256(baseMsg.txID);
-
-        bytes memory extTxID = bytes("ext-test-tx-id");
-        extTxIDHash = sha256(extTxID);
+        bytes32 rawExtTxID = bytes32("ext-test-tx-id");
+        extTxID = rawExtTxID;
 
         AuthAccount.Data[] memory extSigners = new AuthAccount.Data[](1);
         extSigners[0] = AuthAccount.Data({
@@ -206,7 +209,7 @@ contract AuthenticatorTest is Test {
             })
         });
 
-        extMsg = MsgExtSignTx.Data({txID: extTxID, signers: extSigners});
+        extMsg = MsgExtSignTx.Data({txID: abi.encodePacked(rawExtTxID), signers: extSigners});
     }
 
     function test_signTx_SucceedsAsPending() public {
@@ -215,7 +218,7 @@ contract AuthenticatorTest is Test {
         MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
         assertFalse(resp.tx_auth_completed, "response should indicate not completed");
         assertEq(resp.log, "", "log should be empty");
-        assertFalse(harness.completed(txIDHash), "Mock: auth should not be completed");
+        assertFalse(harness.completed(txID), "Mock: auth should not be completed");
         assertEq(harness.runTxCount(), 0, "Mock: runTxIfCompleted should not be called");
     }
 
@@ -223,15 +226,22 @@ contract AuthenticatorTest is Test {
         harness.setSignReturns(true);
 
         vm.expectEmit(true, true, false, true, address(harness));
-        emit IAuthenticator.TxSigned(address(this), txIDHash, AuthType.AuthMode.AUTH_MODE_LOCAL);
+        emit IAuthenticator.TxSigned(address(this), txID, AuthType.AuthMode.AUTH_MODE_LOCAL);
 
         MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
 
         assertTrue(resp.tx_auth_completed, "response should indicate completed");
         assertEq(resp.log, "", "log should be empty");
-        assertTrue(harness.completed(txIDHash), "Mock: auth should be completed");
+        assertTrue(harness.completed(txID), "Mock: auth should be completed");
         assertEq(harness.runTxCount(), 1, "Mock: runTxIfCompleted should be called once");
-        assertEq(harness.lastRunTxID(), txIDHash, "Mock: runTxIfCompleted called with correct txID");
+        assertEq(harness.lastRunTxID(), txID, "Mock: runTxIfCompleted called with correct txID");
+    }
+
+    function test_signTx_RevertsIf_TxIDLengthInvalid() public {
+        baseMsg.txID = bytes("short-id");
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.signTx(baseMsg);
     }
 
     function test_signTx_RevertsIf_SignersLengthZero() public {
@@ -262,14 +272,13 @@ contract AuthenticatorTest is Test {
 
     function test_extSignTx_SucceedsAsPending() public {
         harness.setSignReturns(false);
-
         vm.expectEmit(address(harness));
-        emit IAuthenticator.TxSigned(address(this), extTxIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+        emit IAuthenticator.TxSigned(address(this), extTxID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);
 
         assertTrue(resp.x, "response.x should be true");
-        assertFalse(harness.completed(extTxIDHash), "Mock: auth should not be completed");
+        assertFalse(harness.completed(extTxID), "Mock: auth should not be completed");
         assertEq(harness.runTxCount(), 0, "Mock: runTxIfCompleted should not be called");
     }
 
@@ -277,14 +286,21 @@ contract AuthenticatorTest is Test {
         harness.setSignReturns(true);
 
         vm.expectEmit(address(harness));
-        emit IAuthenticator.TxSigned(address(this), extTxIDHash, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+        emit IAuthenticator.TxSigned(address(this), extTxID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);
 
         assertTrue(resp.x, "response.x should be true");
-        assertTrue(harness.completed(extTxIDHash), "Mock: auth should be completed");
+        assertTrue(harness.completed(extTxID), "Mock: auth should be completed");
         assertEq(harness.runTxCount(), 1, "Mock: runTxIfCompleted should be called once");
-        assertEq(harness.lastRunTxID(), extTxIDHash, "Mock: runTxIfCompleted called with correct txID");
+        assertEq(harness.lastRunTxID(), extTxID, "Mock: runTxIfCompleted called with correct txID");
+    }
+
+    function test_extSignTx_RevertsIf_TxIDLengthInvalid() public {
+        extMsg.txID = new bytes(33);
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.extSignTx(extMsg);
     }
 
     function test_extSignTx_RevertsIfVerificationFails() public {
@@ -295,8 +311,7 @@ contract AuthenticatorTest is Test {
     }
 
     function test_txAuthState_ReturnsState() public {
-        bytes memory queryTxID = bytes("query-tx");
-        bytes32 queryTxIDHash = sha256(queryTxID);
+        bytes32 queryTxID = bytes32("query-tx");
 
         AuthAccount.Data memory signerB = AuthAccount.Data({
             id: signerBBytes,
@@ -311,10 +326,10 @@ contract AuthenticatorTest is Test {
         bool[] memory isRemaining = new bool[](1);
         isRemaining[0] = true;
 
-        harness.setupMockAuthStorage(queryTxIDHash, required, isRemaining);
+        harness.setupMockAuthStorage(queryTxID, required, isRemaining);
 
         QueryTxAuthStateRequest.Data memory req;
-        req.txID = queryTxID;
+        req.txID = abi.encodePacked(queryTxID);
 
         QueryTxAuthStateResponse.Data memory resp = harness.txAuthState(req);
 
@@ -325,6 +340,14 @@ contract AuthenticatorTest is Test {
             uint256(AuthType.AuthMode.AUTH_MODE_LOCAL),
             "Remaining signer auth mode mismatch"
         );
+    }
+
+    function test_txAuthState_RevertsIf_TxIDLengthInvalid() public {
+        QueryTxAuthStateRequest.Data memory req;
+        req.txID = "";
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.txAuthState(req);
     }
 
     function test_accountKey_GeneratesDistinctKeys() public {

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -133,6 +133,10 @@ contract MockTxAuthManager is TxAuthManagerBase {
 }
 
 contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager {
+    function exposed_decodeTxID(bytes calldata rawID) public pure returns (bytes32) {
+        return _decodeTxID(rawID);
+    }
+
     function exposed_accountKey(AuthAccount.Data memory a) public pure returns (bytes32) {
         return _accountKey(a);
     }
@@ -303,11 +307,40 @@ contract AuthenticatorTest is Test, ICrossError {
         harness.extSignTx(extMsg);
     }
 
-    function test_extSignTx_RevertsIfVerificationFails() public {
+    function test_extSignTx_RevertsIf_VerificationFails() public {
         harness.setVerifyShouldRevert(true);
 
         vm.expectRevert(MockTxAuthManager.MockVerifyError.selector);
         harness.extSignTx(extMsg);
+    }
+
+    function test_decodeTxID_SucceedsWith32Bytes() public {
+        bytes32 expected = keccak256("valid-id");
+        bytes memory input = abi.encodePacked(expected);
+
+        bytes32 actual = harness.exposed_decodeTxID(input);
+        assertEq(actual, expected, "Should return correct bytes32 for 32-byte input");
+    }
+
+    function test_decodeTxID_RevertsIf_LengthIsZero() public {
+        bytes memory input = "";
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.exposed_decodeTxID(input);
+    }
+
+    function test_decodeTxID_RevertsIf_LengthIsShort() public {
+        bytes memory input = new bytes(31);
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.exposed_decodeTxID(input);
+    }
+
+    function test_decodeTxID_RevertsIf_LengthIsLong() public {
+        bytes memory input = new bytes(33);
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.exposed_decodeTxID(input);
     }
 
     function test_txAuthState_ReturnsState() public {


### PR DESCRIPTION
- Enforces strict 32-byte length validation for txID inputs in Authenticator.sol methods (signTx, extSignTx, and txAuthState).