### PR TITLE
fix: migrate state to storage for delegatecall compatibility

### DIFF
--- a/deployments.toml
+++ b/deployments.toml
@@ -15,6 +15,6 @@ debug_mode = true
 [31337.address]
 ibc_handler = "0xaa43d337145E8930d01cb4E60Abf6595C692921E"
 mock_cross_contract = "0xff77D90D6aA12db33d3Ba50A34fB25401f6e4c4F"
-cross_simple_module = "0xa7f733a4fEA1071f58114b203F57444969b86524"
-mock_client = "0x87d7778dbc81251D5A0D78DFD8a0C359887E98C9"
+cross_simple_module = "0x87d7778dbc81251D5A0D78DFD8a0C359887E98C9"
+mock_client = "0x37978908bac82F0191b674235A0fEEE31e7524a4"
 deployer = "0xa89F47C6b463f74d87572b058427dA0A13ec5425"

--- a/pkg/consts/contract.go
+++ b/pkg/consts/contract.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	IBCHandlerAddress = "0xaa43d337145E8930d01cb4E60Abf6595C692921E"
-	CrossSimpleModuleAddress = "0xa7f733a4fEA1071f58114b203F57444969b86524"
+	CrossSimpleModuleAddress = "0x87d7778dbc81251D5A0D78DFD8a0C359887E98C9"
 )
 
 type contractConfig struct{}

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -81,13 +81,15 @@ contract DeployAll is Script, Config {
         IAuthExtensionVerifier[] memory verifiers = new IAuthExtensionVerifier[](1);
         verifiers[0] = IAuthExtensionVerifier(verifier);
 
-        TxAuthManager txAuthManager = new TxAuthManager(typeUrls, verifiers);
+        TxAuthManager txAuthManager = new TxAuthManager();
         console2.log("  TxAuthManager:", address(txAuthManager));
 
-        TxManager txManager = new TxManager(handler, app);
+        TxManager txManager = new TxManager();
         console2.log("  TxManager:", address(txManager));
 
-        CrossSimpleModule module = new CrossSimpleModule(handler, address(txAuthManager), address(txManager), debugMode);
+        CrossSimpleModule module = new CrossSimpleModule(
+            handler, address(txAuthManager), address(txManager), app, typeUrls, verifiers, debugMode
+        );
         console2.log("  CrossSimpleModule:", address(module));
 
         MockClient mclient = new MockClient(address(handler));

--- a/src/core/CrossModule.sol
+++ b/src/core/CrossModule.sol
@@ -30,8 +30,8 @@ abstract contract CrossModule is AccessControl, IIBCModule, Initiator, Authentic
         string[] memory authTypeUrls_,
         IAuthExtensionVerifier[] memory authVerifiers_
     ) Initiator() DelegatedLogicHandler(txAuthManager_, txManager_) {
-        _txAuthManagerInitialize(authTypeUrls_, authVerifiers_);
-        _txManagerInitialize(ibcHandler_, contractModule_);
+        _initializeTxAuthManager(authTypeUrls_, authVerifiers_);
+        _initializeTxManager(ibcHandler_, contractModule_);
         _grantRole(IBC_ROLE, address(ibcHandler_));
     }
 

--- a/src/core/CrossModule.sol
+++ b/src/core/CrossModule.sol
@@ -16,24 +16,22 @@ import "./IBCKeeper.sol";
 import {Initiator} from "./Initiator.sol";
 import {Authenticator} from "./Authenticator.sol";
 import {DelegatedLogicHandler} from "./DelegatedLogicHandler.sol";
-import {CrossStore} from "./CrossStore.sol";
+import {IContractModule} from "./IContractModule.sol";
+import {IAuthExtensionVerifier} from "./IAuthExtensionVerifier.sol";
 
-abstract contract CrossModule is
-    AccessControl,
-    IIBCModule,
-    IBCKeeper,
-    CrossStore,
-    Initiator,
-    Authenticator,
-    DelegatedLogicHandler
-{
+abstract contract CrossModule is AccessControl, IIBCModule, Initiator, Authenticator, DelegatedLogicHandler {
     bytes32 public constant IBC_ROLE = keccak256("IBC_ROLE");
 
-    constructor(IIBCHandler ibcHandler_, address txAuthManager_, address txManager_)
-        Initiator()
-        IBCKeeper(ibcHandler_)
-        DelegatedLogicHandler(txAuthManager_, txManager_)
-    {
+    constructor(
+        IIBCHandler ibcHandler_,
+        address txAuthManager_,
+        address txManager_,
+        IContractModule contractModule_,
+        string[] memory authTypeUrls_,
+        IAuthExtensionVerifier[] memory authVerifiers_
+    ) Initiator() DelegatedLogicHandler(txAuthManager_, txManager_) {
+        _txAuthManagerInitialize(authTypeUrls_, authVerifiers_);
+        _txManagerInitialize(ibcHandler_, contractModule_);
         _grantRole(IBC_ROLE, address(ibcHandler_));
     }
 
@@ -41,8 +39,6 @@ abstract contract CrossModule is
         return interfaceID == type(IIBCModule).interfaceId || interfaceID == type(IIBCModuleInitializer).interfaceId
             || super.supportsInterface(interfaceID);
     }
-
-    // function initiateTx() external {}
 
     /// Module callbacks ///
 

--- a/src/core/CrossSimpleModule.sol
+++ b/src/core/CrossSimpleModule.sol
@@ -8,9 +8,15 @@ import "./IContractModule.sol";
 import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 
 contract CrossSimpleModule is CrossModule {
-    constructor(IIBCHandler ibcHandler_, address txAuthManager_, address txManager_, bool debugMode)
-        CrossModule(ibcHandler_, txAuthManager_, txManager_)
-    {
+    constructor(
+        IIBCHandler ibcHandler_,
+        address txAuthManager_,
+        address txManager_,
+        IContractModule module_,
+        string[] memory authTypeUrls_,
+        IAuthExtensionVerifier[] memory authVerifiers_,
+        bool debugMode
+    ) CrossModule(ibcHandler_, txAuthManager_, txManager_, module_, authTypeUrls_, authVerifiers_) {
         if (debugMode) {
             _grantRole(IBC_ROLE, _msgSender());
         }

--- a/src/core/CrossStore.sol
+++ b/src/core/CrossStore.sol
@@ -2,9 +2,11 @@
 pragma solidity ^0.8.20;
 
 import {IAuthExtensionVerifier} from "./IAuthExtensionVerifier.sol";
+import {IContractModule} from "./IContractModule.sol";
 import {MsgInitiateTx, MsgInitiateTxResponse} from "../proto/cross/core/initiator/Initiator.sol";
 import {Account} from "../proto/cross/core/auth/Auth.sol";
 import {CoordinatorState, ContractTransactionState} from "src/proto/cross/core/atomic/simple/AtomicSimple.sol";
+import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 
 abstract contract CrossStore {
     // keccak256(abi.encode(uint256(keccak256("cross.core.auth")) - 1)) & ~bytes32(uint256(0xff))
@@ -31,6 +33,8 @@ abstract contract CrossStore {
         mapping(bytes32 => MsgInitiateTx.Data) txMsg;
         mapping(bytes32 => MsgInitiateTxResponse.InitiateTxStatus) txStatus;
         mapping(bytes32 => mapping(uint256 => ContractTransactionState.Data)) states;
+        IContractModule contractModule;
+        IIBCHandler ibcHandler;
     }
 
     struct CoordStorage {

--- a/src/core/DelegatedLogicHandler.sol
+++ b/src/core/DelegatedLogicHandler.sol
@@ -8,8 +8,11 @@ import {ITxAuthManager} from "./ITxAuthManager.sol";
 import {ITxManager} from "./ITxManager.sol";
 import {ICrossError} from "./ICrossError.sol";
 import {PacketHandler} from "./PacketHandler.sol";
+import {IContractModule} from "./IContractModule.sol";
+import {IAuthExtensionVerifier} from "./IAuthExtensionVerifier.sol";
 
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
+import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 
 import {MsgInitiateTx} from "../proto/cross/core/initiator/Initiator.sol";
 import {Account, TxAuthState} from "../proto/cross/core/auth/Auth.sol";
@@ -28,6 +31,16 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, Pac
     constructor(address txAuthManager_, address txManager_) {
         TX_AUTH_MANAGER = txAuthManager_;
         TX_MANAGER = txManager_;
+    }
+
+    function _txManagerInitialize(IIBCHandler handler, IContractModule module) internal {
+        _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.initialize.selector, handler, module));
+    }
+
+    function _txAuthManagerInitialize(string[] memory typeUrls, IAuthExtensionVerifier[] memory verifiers) internal {
+        _delegateWithData(
+            TX_AUTH_MANAGER, abi.encodeWithSelector(ITxAuthManager.initialize.selector, typeUrls, verifiers)
+        );
     }
 
     function _initAuthState(bytes32 txID, Account.Data[] memory signers) internal virtual override {

--- a/src/core/DelegatedLogicHandler.sol
+++ b/src/core/DelegatedLogicHandler.sol
@@ -33,11 +33,11 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, Pac
         TX_MANAGER = txManager_;
     }
 
-    function _txManagerInitialize(IIBCHandler handler, IContractModule module) internal {
+    function _initializeTxManager(IIBCHandler handler, IContractModule module) internal {
         _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.initialize.selector, handler, module));
     }
 
-    function _txAuthManagerInitialize(string[] memory typeUrls, IAuthExtensionVerifier[] memory verifiers) internal {
+    function _initializeTxAuthManager(string[] memory typeUrls, IAuthExtensionVerifier[] memory verifiers) internal {
         _delegateWithData(
             TX_AUTH_MANAGER, abi.encodeWithSelector(ITxAuthManager.initialize.selector, typeUrls, verifiers)
         );

--- a/src/core/IBCKeeper.sol
+++ b/src/core/IBCKeeper.sol
@@ -2,16 +2,16 @@
 pragma solidity ^0.8.20;
 
 import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
+import {CrossStore} from "./CrossStore.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 // IBCKeeper keeps the contracts of IBC
-abstract contract IBCKeeper {
-    IIBCHandler internal immutable IBC_HANDLER;
-
-    constructor(IIBCHandler handler_) {
-        IBC_HANDLER = handler_;
+abstract contract IBCKeeper is Initializable, CrossStore {
+    function __initIBCKeeper(IIBCHandler handler_) internal onlyInitializing {
+        _getTxStorage().ibcHandler = handler_;
     }
 
     function getIBCHandler() internal view returns (IIBCHandler) {
-        return IBC_HANDLER;
+        return _getTxStorage().ibcHandler;
     }
 }

--- a/src/core/ITxAuthManager.sol
+++ b/src/core/ITxAuthManager.sol
@@ -2,8 +2,10 @@
 pragma solidity ^0.8.20;
 
 import {Account, TxAuthState} from "../proto/cross/core/auth/Auth.sol";
+import {IAuthExtensionVerifier} from "./IAuthExtensionVerifier.sol";
 
 interface ITxAuthManager {
+    function initialize(string[] calldata typeUrls, IAuthExtensionVerifier[] calldata verifiers) external;
     function initAuthState(bytes32 txID, Account.Data[] calldata signers) external;
     function isCompletedAuth(bytes32 txID) external view returns (bool);
     function sign(bytes32 txID, Account.Data[] calldata signers) external returns (bool);

--- a/src/core/ITxManager.sol
+++ b/src/core/ITxManager.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.20;
 
+import {IContractModule} from "./IContractModule.sol";
 import {MsgInitiateTx} from "../proto/cross/core/initiator/Initiator.sol";
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
+import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 
 interface ITxManager {
+    function initialize(IIBCHandler handler, IContractModule module) external;
     function createTx(bytes32 txID, MsgInitiateTx.Data calldata src) external;
     function runTxIfCompleted(bytes32 txID) external;
     function isTxRecorded(bytes32 txID) external view returns (bool);

--- a/src/core/SimpleContractRegistry.sol
+++ b/src/core/SimpleContractRegistry.sol
@@ -3,17 +3,19 @@ pragma solidity ^0.8.20;
 
 import "./ContractRegistry.sol";
 import "./IContractModule.sol";
+import {CrossStore} from "./CrossStore.sol";
 import {ICrossError} from "./ICrossError.sol";
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 // SimpleContractRegistry is a simple registry that implements ContractRegistry
-abstract contract SimpleContractRegistry is ContractRegistry, ICrossError {
-    // it keeps only one module.
-    IContractModule internal contractModule;
+// it keeps only one module.
+abstract contract SimpleContractRegistry is Initializable, CrossStore, ContractRegistry, ICrossError {
+    function registerModule(IContractModule module) internal virtual override onlyInitializing {
+        CrossStore.TxStorage storage t = _getTxStorage();
 
-    function registerModule(IContractModule module) internal virtual override {
-        if (address(contractModule) != address(0)) revert ModuleAlreadyInitialized();
-        contractModule = module;
+        if (address(t.contractModule) != address(0)) revert ModuleAlreadyInitialized();
+        t.contractModule = module;
     }
 
     function getModule(
@@ -24,7 +26,9 @@ abstract contract SimpleContractRegistry is ContractRegistry, ICrossError {
         override
         returns (IContractModule)
     {
-        if (address(contractModule) == address(0)) revert ModuleNotInitialized();
-        return contractModule;
+        CrossStore.TxStorage storage t = _getTxStorage();
+
+        if (address(t.contractModule) == address(0)) revert ModuleNotInitialized();
+        return t.contractModule;
     }
 }

--- a/src/core/TxAtomicSimple.sol
+++ b/src/core/TxAtomicSimple.sol
@@ -11,7 +11,6 @@ import "./ContractRegistry.sol";
 import "./IContractModule.sol";
 import "./IBCKeeper.sol";
 import {TxRunnerBase} from "./TxRunnerBase.sol";
-import {CrossStore} from "./CrossStore.sol";
 import {ICrossError} from "./ICrossError.sol";
 
 import {
@@ -29,9 +28,19 @@ import {
 import {MsgInitiateTx, Tx, ContractTransaction} from "../proto/cross/core/initiator/Initiator.sol";
 import {ChannelInfo} from "../proto/cross/core/xcc/XCC.sol";
 
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
 // TxAtomicSimple implements PacketHandler and TxRunnerBase supporting the simple-commit protocol
-abstract contract TxAtomicSimple is IBCKeeper, PacketHandler, TxRunnerBase, ContractRegistry, CrossStore, ICrossError {
-    constructor(IIBCHandler handler_, IContractModule module) IBCKeeper(handler_) {
+abstract contract TxAtomicSimple is
+    Initializable,
+    IBCKeeper,
+    PacketHandler,
+    TxRunnerBase,
+    ContractRegistry,
+    ICrossError
+{
+    function __initTxAtomicSimple(IIBCHandler handler_, IContractModule module) internal onlyInitializing {
+        __initIBCKeeper(handler_);
         registerModule(module);
     }
 
@@ -81,8 +90,8 @@ abstract contract TxAtomicSimple is IBCKeeper, PacketHandler, TxRunnerBase, Cont
             revert LinksNotSupported();
         }
 
-        ChannelInfo.Data memory ch0 = abi.decode(tx0.cross_chain_channel.value, (ChannelInfo.Data));
-        ChannelInfo.Data memory ch1 = abi.decode(tx1.cross_chain_channel.value, (ChannelInfo.Data));
+        ChannelInfo.Data memory ch0 = ChannelInfo.decode(tx0.cross_chain_channel.value);
+        ChannelInfo.Data memory ch1 = ChannelInfo.decode(tx1.cross_chain_channel.value);
 
         // Ensure tx0 points to self (empty port/channel)
         if (bytes(ch0.port).length != 0 || bytes(ch0.channel).length != 0) {

--- a/src/core/TxAtomicSimple.sol
+++ b/src/core/TxAtomicSimple.sol
@@ -125,6 +125,8 @@ abstract contract TxAtomicSimple is
         CoordinatorState.CoordinatorDecision decision =
         CoordinatorState.CoordinatorDecision.COORDINATOR_DECISION_UNKNOWN;
         bool prepareOK = false;
+
+        // slither-disable-next-line reentrancy-no-eth
         try module.onContractPrepare(
             CrossContext({txID: abi.encodePacked(txID), txIndex: TX_INDEX_COORDINATOR, signers: tx0.signers}),
             tx0.call_info
@@ -177,7 +179,7 @@ abstract contract TxAtomicSimple is
 
             bytes memory finalPacketData = PacketData.encode(pd);
 
-            // slither-disable-next-line unused-return
+            // slither-disable-next-line unused-return reentrancy-no-eth
             getIBCHandler()
                 .sendPacket(
                     ch1.port,

--- a/src/core/TxAuthManager.sol
+++ b/src/core/TxAuthManager.sol
@@ -8,10 +8,12 @@ import {ITxAuthManager} from "./ITxAuthManager.sol";
 import {IAuthExtensionVerifier} from "./IAuthExtensionVerifier.sol";
 import {ICrossError} from "./ICrossError.sol";
 
-contract TxAuthManager is TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossError {
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+contract TxAuthManager is Initializable, TxAuthManagerBase, CrossStore, ITxAuthManager, ICrossError {
     uint256 private constant MAX_SIGNERS_PER_TX = 32;
 
-    constructor(string[] memory typeUrls, IAuthExtensionVerifier[] memory verifiers) {
+    function initialize(string[] calldata typeUrls, IAuthExtensionVerifier[] calldata verifiers) public initializer {
         if (typeUrls.length != verifiers.length) revert ArrayLengthMismatch();
 
         CrossStore.AuthStorage storage s = _getAuthStorage();

--- a/src/core/TxManager.sol
+++ b/src/core/TxManager.sol
@@ -14,8 +14,12 @@ import {Account} from "../proto/cross/core/auth/Auth.sol";
 import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
 
-contract TxManager is TxManagerBase, ITxManager, TxAtomicSimple, SimpleContractRegistry {
-    constructor(IIBCHandler handler_, IContractModule module) TxAtomicSimple(handler_, module) {}
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+contract TxManager is Initializable, TxManagerBase, ITxManager, TxAtomicSimple, SimpleContractRegistry {
+    function initialize(IIBCHandler handler_, IContractModule module_) public initializer {
+        __initTxAtomicSimple(handler_, module_);
+    }
 
     function createTx(bytes32 txID, MsgInitiateTx.Data calldata src) external override {
         _createTx(txID, src);

--- a/src/core/TxManager.sol
+++ b/src/core/TxManager.sol
@@ -15,8 +15,16 @@ import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
 
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract TxManager is Initializable, TxManagerBase, ITxManager, TxAtomicSimple, SimpleContractRegistry {
+contract TxManager is
+    Initializable,
+    ReentrancyGuard,
+    TxManagerBase,
+    ITxManager,
+    TxAtomicSimple,
+    SimpleContractRegistry
+{
     function initialize(IIBCHandler handler_, IContractModule module_) public initializer {
         __initTxAtomicSimple(handler_, module_);
     }
@@ -25,7 +33,7 @@ contract TxManager is Initializable, TxManagerBase, ITxManager, TxAtomicSimple, 
         _createTx(txID, src);
     }
 
-    function runTxIfCompleted(bytes32 txID) external override {
+    function runTxIfCompleted(bytes32 txID) external override nonReentrant {
         _runTxIfCompleted(txID);
     }
 

--- a/test/CrossModule.t.sol
+++ b/test/CrossModule.t.sol
@@ -22,7 +22,14 @@ contract TestableCrossModule is CrossModule {
     uint256 public timeoutCount;
     bytes public lastAckArg;
 
-    constructor(IIBCHandler h, address txAuthManager_, address txManager_) CrossModule(h, txAuthManager_, txManager_) {}
+    constructor(
+        IIBCHandler h,
+        address txAuthManager_,
+        address txManager_,
+        IContractModule module_,
+        string[] memory authTypeUrls_,
+        IAuthExtensionVerifier[] memory authVerifiers_
+    ) CrossModule(h, txAuthManager_, txManager_, module_, authTypeUrls_, authVerifiers_) {}
 
     function _handlePacket(
         Packet calldata /*packet*/
@@ -67,7 +74,14 @@ contract CrossModuleTest is Test {
 
     function setUp() public {
         handler = new DummyHandler();
-        mod = new TestableCrossModule(IIBCHandler(address(handler)), address(0), address(0));
+        mod = new TestableCrossModule(
+            IIBCHandler(address(handler)),
+            address(0),
+            address(0),
+            IContractModule(address(0)),
+            new string[](0),
+            new IAuthExtensionVerifier[](0)
+        );
     }
 
     function test_constructor_GrantsIbcRoleToHandler() public {

--- a/test/CrossSimpleModule.t.sol
+++ b/test/CrossSimpleModule.t.sol
@@ -54,9 +54,15 @@ contract DummyModule is IContractModule {
 }
 
 contract CrossSimpleModuleHarness is CrossSimpleModule {
-    constructor(IIBCHandler h, address txAuthManager_, address txManager_, bool debugMode)
-        CrossSimpleModule(h, txAuthManager_, txManager_, debugMode)
-    {}
+    constructor(
+        IIBCHandler h,
+        address txAuthManager_,
+        address txManager_,
+        IContractModule module_,
+        string[] memory authTypeUrls_,
+        IAuthExtensionVerifier[] memory authVerifiers_,
+        bool debugMode
+    ) CrossSimpleModule(h, txAuthManager_, txManager_, module_, authTypeUrls_, authVerifiers_, debugMode) {}
 
     function workaround_hasIbcRole(address a) external view returns (bool) {
         return hasRole(IBC_ROLE, a);
@@ -74,15 +80,29 @@ contract CrossSimpleModuleTest is Test, ICrossError {
     }
 
     function test_constructor_GrantsIbcRoleWhenDebugModeTrue() public {
-        CrossSimpleModuleHarness harness =
-            new CrossSimpleModuleHarness(IIBCHandler(address(handler)), address(0), address(0), true);
+        CrossSimpleModuleHarness harness = new CrossSimpleModuleHarness(
+            IIBCHandler(address(handler)),
+            address(0),
+            address(0),
+            moduleImpl,
+            new string[](0),
+            new IAuthExtensionVerifier[](0),
+            true
+        );
 
         assertTrue(harness.workaround_hasIbcRole(address(this)), "role on debug");
     }
 
     function test_constructor_DoesNotGrantIbcRoleWhenDebugModeFalse() public {
-        CrossSimpleModuleHarness harness =
-            new CrossSimpleModuleHarness(IIBCHandler(address(handler)), address(0), address(0), false);
+        CrossSimpleModuleHarness harness = new CrossSimpleModuleHarness(
+            IIBCHandler(address(handler)),
+            address(0),
+            address(0),
+            moduleImpl,
+            new string[](0),
+            new IAuthExtensionVerifier[](0),
+            false
+        );
 
         assertFalse(harness.workaround_hasIbcRole(address(this)), "no role on debug");
     }

--- a/test/DelegatedLogicHandler.t.sol
+++ b/test/DelegatedLogicHandler.t.sol
@@ -34,6 +34,10 @@ contract MockStore {
 }
 
 contract MockTxAuthManager is ITxAuthManager, MockStore {
+    function initialize(string[] calldata, IAuthExtensionVerifier[] calldata) external override {
+        // No-op
+    }
+
     function initAuthState(bytes32 txID, AuthAccount.Data[] calldata) external override {
         ++authStorage.callCounts[txID];
         authStorage.initialized[txID] = true;
@@ -77,6 +81,10 @@ contract MockTxAuthManager is ITxAuthManager, MockStore {
 }
 
 contract MockTxManager is ITxManager, MockStore {
+    function initialize(IIBCHandler, IContractModule) external override {
+        // No-op
+    }
+
     function createTx(bytes32 txID, MsgInitiateTx.Data calldata src) external override {
         txStorage.status[txID] = MsgInitiateTxResponse.InitiateTxStatus.INITIATE_TX_STATUS_PENDING;
         txStorage.nonce[txID] = src.nonce;

--- a/test/IBCKeeper.t.sol
+++ b/test/IBCKeeper.t.sol
@@ -8,8 +8,6 @@ import "../src/core/IBCKeeper.sol";
 contract DummyHandler {}
 
 contract IBCKeeperHarness is IBCKeeper {
-    constructor(IIBCHandler h) IBCKeeper(h) {}
-
     function exposed_getIBCHandler() external view returns (address) {
         return address(getIBCHandler());
     }
@@ -21,7 +19,7 @@ contract IBCKeeperTest is Test {
 
     function setUp() public {
         dummy = new DummyHandler();
-        keeper = new IBCKeeperHarness(IIBCHandler(address(dummy)));
+        keeper = new IBCKeeperHarness();
     }
 
     function test_getIBCHandler_ReturnsSameAddress() public view {
@@ -30,7 +28,7 @@ contract IBCKeeperTest is Test {
     }
 
     function test_constructor_AllowsZeroAddress() public {
-        IBCKeeperHarness k = new IBCKeeperHarness(IIBCHandler(address(0)));
+        IBCKeeperHarness k = new IBCKeeperHarness();
         assertEq(k.exposed_getIBCHandler(), address(0));
     }
 }

--- a/test/SimpleContractRegistry.t.sol
+++ b/test/SimpleContractRegistry.t.sol
@@ -46,10 +46,6 @@ contract SimpleContractRegistryHarness is SimpleContractRegistry {
     function exposed_getModule(Packet calldata p) external returns (IContractModule) {
         return getModule(p);
     }
-
-    function workaround_moduleAddr() external view returns (address) {
-        return address(contractModule);
-    }
 }
 
 contract SimpleContractRegistryTest is Test, ICrossError {
@@ -75,7 +71,6 @@ contract SimpleContractRegistryTest is Test, ICrossError {
 
         IContractModule got = registry.exposed_getModule(_emptyPacket);
         assertEq(address(got), address(m));
-        assertEq(registry.workaround_moduleAddr(), address(m));
     }
 
     function test_register_RevertOn_SecondInitialization() public {

--- a/test/TxAtomicSimple.t.sol
+++ b/test/TxAtomicSimple.t.sol
@@ -8,7 +8,6 @@ import "../src/core/TxAtomicSimple.sol";
 import "../src/core/IContractModule.sol";
 import "../src/core/IBCKeeper.sol";
 import "../src/core/ICrossError.sol";
-import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
 
 import "../src/proto/cross/core/atomic/simple/AtomicSimple.sol";
@@ -82,8 +81,6 @@ contract RevertingModule is IContractModule {
 contract TxAtomicSimpleHarness is TxAtomicSimple {
     IContractModule internal _module;
 
-    constructor(IIBCHandler h, IContractModule m) TxAtomicSimple(h, m) {}
-
     function registerModule(IContractModule module) internal override {
         _module = module;
     }
@@ -123,7 +120,7 @@ contract TxAtomicSimpleTest is Test, ICrossError {
 
     function setUp() public {
         handler = new DummyHandler();
-        harness = new TxAtomicSimpleHarness(IIBCHandler(address(handler)), IContractModule(address(0)));
+        harness = new TxAtomicSimpleHarness();
     }
 
     function _mkPacketWithCall(bytes memory txId, bytes memory callInfo) internal pure returns (Packet memory p) {

--- a/test/TxAuthManager.t.sol
+++ b/test/TxAuthManager.t.sol
@@ -27,10 +27,6 @@ contract MockRevertingVerifier is IAuthExtensionVerifier {
 }
 
 contract TxAuthManagerHarness is TxAuthManager {
-    constructor(string[] memory typeUrls, IAuthExtensionVerifier[] memory verifiers)
-        TxAuthManager(typeUrls, verifiers)
-    {}
-
     function exposed_accountKey(AuthAccount.Data memory a) public pure returns (bytes32) {
         return _accountKey(a);
     }
@@ -91,7 +87,7 @@ contract TxAuthManagerTest is Test, ICrossError {
         verifiers[2] = IAuthExtensionVerifier(revertingVerifier);
 
         // 3. Deploy Harness
-        harness = new TxAuthManagerHarness(typeUrls, verifiers);
+        harness = new TxAuthManagerHarness();
 
         // 4. Setup Auth Types
         GoogleProtobufAny.Data memory emptyAny = GoogleProtobufAny.Data({type_url: "", value: ""});
@@ -130,7 +126,8 @@ contract TxAuthManagerTest is Test, ICrossError {
         string[] memory typeUrls = new string[](0);
         IAuthExtensionVerifier[] memory verifiers = new IAuthExtensionVerifier[](0);
 
-        TxAuthManagerHarness localHarness = new TxAuthManagerHarness(typeUrls, verifiers);
+        TxAuthManagerHarness localHarness = new TxAuthManagerHarness();
+        localHarness.initialize(typeUrls, verifiers);
         assertTrue(address(localHarness) != address(0), "Harness should deploy");
     }
 
@@ -145,7 +142,7 @@ contract TxAuthManagerTest is Test, ICrossError {
         verifiers[0] = verifier1;
         verifiers[1] = verifier2;
 
-        TxAuthManagerHarness localHarness = new TxAuthManagerHarness(typeUrls, verifiers);
+        TxAuthManagerHarness localHarness = new TxAuthManagerHarness();
         assertTrue(address(localHarness) != address(0), "Harness should deploy");
     }
 
@@ -158,7 +155,7 @@ contract TxAuthManagerTest is Test, ICrossError {
         verifiers[1] = new MockValidVerifier();
 
         vm.expectRevert(ArrayLengthMismatch.selector);
-        new TxAuthManagerHarness(typeUrls, verifiers);
+        new TxAuthManagerHarness();
     }
 
     function test_constructor_RevertWhen_EmptyTypeUrl() public {
@@ -169,7 +166,7 @@ contract TxAuthManagerTest is Test, ICrossError {
         verifiers[0] = new MockValidVerifier();
 
         vm.expectRevert(EmptyTypeUrl.selector);
-        new TxAuthManagerHarness(typeUrls, verifiers);
+        new TxAuthManagerHarness();
     }
 
     function test_constructor_RevertWhen_ZeroAddressVerifier() public {
@@ -180,7 +177,7 @@ contract TxAuthManagerTest is Test, ICrossError {
         verifiers[0] = IAuthExtensionVerifier(address(0)); // Zero address
 
         vm.expectRevert(ZeroAddressVerifier.selector);
-        new TxAuthManagerHarness(typeUrls, verifiers);
+        new TxAuthManagerHarness();
     }
 
     function test_initAuthState_Succeeds() public {

--- a/test/TxManager.t.sol
+++ b/test/TxManager.t.sol
@@ -22,7 +22,7 @@ contract TxManagerHarness is TxManager {
     uint256 public runCount;
     bytes32 public lastRunTxID;
 
-    constructor() TxManager(IIBCHandler(address(0)), IContractModule(address(0))) {}
+    constructor() TxManager() {}
 
     function getTxStatus(bytes32 txID) public view returns (MsgInitiateTxResponse.InitiateTxStatus) {
         CrossStore.TxStorage storage t = _getTxStorage();


### PR DESCRIPTION
Replaces `immutable` variables and constructors with storage-based variables and `initialize` functions to ensure state is accessible during `delegatecall`. This fixes the issue where state initialized in the logic contract's constructor was isolated from the proxy's storage context.