### PR TITLE
feat: impl Coordinator.sol

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 solc_version = "0.8.30"
 libs = ["lib", "node_modules"]
 optimizer = true
-optimizer_runs = 1000
+optimizer_runs = 200
 evm_version = "london"
 fs_permissions = [
   { access = "read-write", path = "./deployments.toml" }

--- a/src/core/Coordinator.sol
+++ b/src/core/Coordinator.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import {ICoordinator} from "./ICoordinator.sol";
+import {TxManagerBase} from "./TxManagerBase.sol";
+import {ICrossError} from "./ICrossError.sol";
+
+import {
+    QueryCoordinatorStateRequest,
+    QueryCoordinatorStateResponse,
+    CoordinatorState
+} from "../proto/cross/core/atomic/simple/AtomicSimple.sol";
+
+abstract contract Coordinator is TxManagerBase, ICoordinator, ICrossError {
+    function coordinatorState(QueryCoordinatorStateRequest.Data calldata req)
+        external
+        view
+        override
+        returns (QueryCoordinatorStateResponse.Data memory)
+    {
+        if (req.tx_id.length != 32) {
+            revert InvalidTxIDLength();
+        }
+        bytes32 txID = abi.decode(req.tx_id, (bytes32));
+
+        CoordinatorState.Data memory state = _getCoordinatorState(txID);
+
+        return QueryCoordinatorStateResponse.Data({coodinator_state: state});
+    }
+}

--- a/src/core/CrossModule.sol
+++ b/src/core/CrossModule.sol
@@ -15,11 +15,19 @@ import "./IBCKeeper.sol";
 
 import {Initiator} from "./Initiator.sol";
 import {Authenticator} from "./Authenticator.sol";
+import {Coordinator} from "./Coordinator.sol";
 import {DelegatedLogicHandler} from "./DelegatedLogicHandler.sol";
 import {IContractModule} from "./IContractModule.sol";
 import {IAuthExtensionVerifier} from "./IAuthExtensionVerifier.sol";
 
-abstract contract CrossModule is AccessControl, IIBCModule, Initiator, Authenticator, DelegatedLogicHandler {
+abstract contract CrossModule is
+    AccessControl,
+    IIBCModule,
+    Initiator,
+    Authenticator,
+    Coordinator,
+    DelegatedLogicHandler
+{
     bytes32 public constant IBC_ROLE = keccak256("IBC_ROLE");
 
     constructor(

--- a/src/core/DelegatedLogicHandler.sol
+++ b/src/core/DelegatedLogicHandler.sol
@@ -16,6 +16,7 @@ import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-
 
 import {MsgInitiateTx} from "../proto/cross/core/initiator/Initiator.sol";
 import {Account, TxAuthState} from "../proto/cross/core/auth/Auth.sol";
+import {CoordinatorState} from "../proto/cross/core/atomic/simple/AtomicSimple.sol";
 
 abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, PacketHandler, ICrossError {
     address public immutable TX_AUTH_MANAGER;
@@ -134,6 +135,24 @@ abstract contract DelegatedLogicHandler is TxAuthManagerBase, TxManagerBase, Pac
 
     function _handleTimeout(Packet calldata packet) internal virtual override {
         _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.handleTimeout.selector, packet));
+    }
+
+    function _getCoordinatorState(bytes32 txID) internal view virtual override returns (CoordinatorState.Data memory) {
+        bytes memory ret = _staticCallSelf(abi.encodeWithSelector(this.__getCoordinatorState.selector, txID));
+        return abi.decode(ret, (CoordinatorState.Data));
+    }
+
+    /**
+     * @dev Internal function called via staticcall to read state via delegatecall.
+     * * NOTE: Since this function is called via `address(this).staticcall`,
+     * the `msg.sender` inside the delegated implementation (TxManager)
+     * will be THIS contract address, NOT the original caller.
+     * Do not rely on `msg.sender` for access control in the implementation logic.
+     */
+    function __getCoordinatorState(bytes32 txID) external onlySelf returns (CoordinatorState.Data memory) {
+        bytes memory ret =
+            _delegateWithData(TX_MANAGER, abi.encodeWithSelector(ITxManager.getCoordinatorState.selector, txID));
+        return abi.decode(ret, (CoordinatorState.Data));
     }
 
     function _delegateWithData(address impl, bytes memory data) internal returns (bytes memory) {

--- a/src/core/ITxManager.sol
+++ b/src/core/ITxManager.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import {IContractModule} from "./IContractModule.sol";
 import {MsgInitiateTx} from "../proto/cross/core/initiator/Initiator.sol";
+import {CoordinatorState} from "../proto/cross/core/atomic/simple/AtomicSimple.sol";
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
 import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 
@@ -11,6 +12,7 @@ interface ITxManager {
     function createTx(bytes32 txID, MsgInitiateTx.Data calldata src) external;
     function runTxIfCompleted(bytes32 txID) external;
     function isTxRecorded(bytes32 txID) external view returns (bool);
+    function getCoordinatorState(bytes32 txID) external view returns (CoordinatorState.Data memory);
     function handlePacket(Packet calldata packet) external returns (bytes memory acknowledgement);
     function handleAcknowledgement(Packet calldata packet, bytes calldata acknowledgement) external;
     function handleTimeout(Packet calldata packet) external;

--- a/src/core/TxManager.sol
+++ b/src/core/TxManager.sol
@@ -10,7 +10,8 @@ import {TxAtomicSimple} from "./TxAtomicSimple.sol";
 
 import {MsgInitiateTx, MsgInitiateTxResponse, ContractTransaction} from "../proto/cross/core/initiator/Initiator.sol";
 import {Account} from "../proto/cross/core/auth/Auth.sol";
-import {PacketAcknowledgementCall} from "../proto/cross/core/atomic/simple/AtomicSimple.sol";
+import {PacketAcknowledgementCall, CoordinatorState} from "../proto/cross/core/atomic/simple/AtomicSimple.sol";
+import {Tx} from "../proto/cross/core/tx/Tx.sol";
 
 import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
@@ -40,6 +41,10 @@ contract TxManager is
 
     function isTxRecorded(bytes32 txID) external view override returns (bool) {
         return _isTxRecorded(txID);
+    }
+
+    function getCoordinatorState(bytes32 txID) external view returns (CoordinatorState.Data memory) {
+        return _getCoordinatorState(txID);
     }
 
     function handlePacket(Packet calldata packet) external returns (bytes memory acknowledgement) {
@@ -74,6 +79,14 @@ contract TxManager is
     function _isTxRecorded(bytes32 txID) internal view virtual override returns (bool) {
         CrossStore.TxStorage storage t = _getTxStorage();
         return t.txStatus[txID] != MsgInitiateTxResponse.InitiateTxStatus.INITIATE_TX_STATUS_UNKNOWN;
+    }
+
+    function _getCoordinatorState(bytes32 txID) internal view override returns (CoordinatorState.Data memory) {
+        CrossStore.CoordStorage storage s = _getCoordStorage();
+        if (s.states[txID].commit_protocol == Tx.CommitProtocol.COMMIT_PROTOCOL_UNKNOWN) {
+            revert CoordinatorStateNotFound(txID);
+        }
+        return s.states[txID];
     }
 
     function _deepStoreMsg(CrossStore.TxStorage storage t, bytes32 txID, MsgInitiateTx.Data calldata src) private {

--- a/src/core/TxManagerBase.sol
+++ b/src/core/TxManagerBase.sol
@@ -2,9 +2,11 @@
 pragma solidity ^0.8.20;
 
 import {MsgInitiateTx} from "../proto/cross/core/initiator/Initiator.sol";
+import {CoordinatorState} from "../proto/cross/core/atomic/simple/AtomicSimple.sol";
 
 abstract contract TxManagerBase {
     function _createTx(bytes32 txID, MsgInitiateTx.Data calldata src) internal virtual;
     function _runTxIfCompleted(bytes32 txID) internal virtual;
     function _isTxRecorded(bytes32 txID) internal view virtual returns (bool);
+    function _getCoordinatorState(bytes32 txID) internal view virtual returns (CoordinatorState.Data memory);
 }

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -22,6 +22,7 @@ import {
     GoogleProtobufAny
 } from "../src/proto/cross/core/auth/Auth.sol";
 import {IbcCoreClientV1Height} from "../src/proto/ibc/core/client/v1/client.sol";
+import {CoordinatorState} from "../src/proto/cross/core/atomic/simple/AtomicSimple.sol";
 
 contract MockTxManager is TxManagerBase {
     bytes32 public lastRunTxID;
@@ -52,6 +53,19 @@ contract MockTxManager is TxManagerBase {
         returns (bool)
     {
         return false;
+    }
+
+    function _getCoordinatorState(
+        bytes32 /*txID*/
+    )
+        internal
+        view
+        virtual
+        override
+        returns (CoordinatorState.Data memory)
+    {
+        CoordinatorState.Data memory dummy;
+        return dummy;
     }
 }
 

--- a/test/Coordinator.t.sol
+++ b/test/Coordinator.t.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// solhint-disable one-contract-per-file, func-name-mixedcase, gas-small-strings
+pragma solidity ^0.8.20;
+
+import "forge-std/src/Test.sol";
+import "../src/core/Coordinator.sol";
+import "../src/core/TxManagerBase.sol";
+import {ICrossError} from "../src/core/ICrossError.sol";
+import {
+    QueryCoordinatorStateRequest,
+    QueryCoordinatorStateResponse,
+    CoordinatorState
+} from "../src/proto/cross/core/atomic/simple/AtomicSimple.sol";
+import {MsgInitiateTx} from "../src/proto/cross/core/initiator/Initiator.sol";
+import {Tx} from "../src/proto/cross/core/tx/Tx.sol";
+
+contract MockTxManager is TxManagerBase, ICrossError {
+    mapping(bytes32 => CoordinatorState.Data) internal mockStates;
+    mapping(bytes32 => bool) internal exists;
+
+    function setCoordinatorState(bytes32 txID, CoordinatorState.Data memory data) public {
+        mockStates[txID] = data;
+        exists[txID] = true;
+    }
+
+    function _getCoordinatorState(bytes32 txID) internal view virtual override returns (CoordinatorState.Data memory) {
+        if (!exists[txID]) {
+            revert CoordinatorStateNotFound(txID);
+        }
+        return mockStates[txID];
+    }
+
+    function _createTx(bytes32, MsgInitiateTx.Data calldata) internal virtual override {}
+    function _runTxIfCompleted(bytes32) internal virtual override {}
+
+    function _isTxRecorded(bytes32) internal view virtual override returns (bool) {
+        return false;
+    }
+}
+
+contract CoordinatorHarness is Coordinator, MockTxManager {}
+
+contract CoordinatorTest is Test, ICrossError {
+    CoordinatorHarness private harness;
+    bytes32 private txID = keccak256("test_tx_id");
+
+    function setUp() public {
+        harness = new CoordinatorHarness();
+    }
+
+    function test_coordinatorState_ReturnsCorrectState() public {
+        CoordinatorState.Data memory expectedState;
+        expectedState.commit_protocol = Tx.CommitProtocol.COMMIT_PROTOCOL_SIMPLE;
+        expectedState.phase = CoordinatorState.CoordinatorPhase.COORDINATOR_PHASE_PREPARE;
+        expectedState.decision = CoordinatorState.CoordinatorDecision.COORDINATOR_DECISION_COMMIT;
+
+        harness.setCoordinatorState(txID, expectedState);
+
+        QueryCoordinatorStateRequest.Data memory req;
+        req.tx_id = abi.encodePacked(txID);
+
+        QueryCoordinatorStateResponse.Data memory resp = harness.coordinatorState(req);
+
+        assertEq(
+            uint256(resp.coodinator_state.commit_protocol),
+            uint256(expectedState.commit_protocol),
+            "Commit protocol mismatch"
+        );
+        assertEq(uint256(resp.coodinator_state.phase), uint256(expectedState.phase), "Phase mismatch");
+        assertEq(uint256(resp.coodinator_state.decision), uint256(expectedState.decision), "Decision mismatch");
+    }
+
+    function test_coordinatorState_RevertIf_TxIDLengthInvalid_TooShort() public {
+        QueryCoordinatorStateRequest.Data memory req;
+        req.tx_id = hex"1234";
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.coordinatorState(req);
+    }
+
+    function test_coordinatorState_RevertIf_TxIDLengthInvalid_TooLong() public {
+        QueryCoordinatorStateRequest.Data memory req;
+        req.tx_id = new bytes(33);
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.coordinatorState(req);
+    }
+
+    function test_coordinatorState_RevertIf_TxIDLengthInvalid_Empty() public {
+        QueryCoordinatorStateRequest.Data memory req;
+        req.tx_id = "";
+
+        vm.expectRevert(InvalidTxIDLength.selector);
+        harness.coordinatorState(req);
+    }
+
+    function test_coordinatorState_RevertIf_StateNotFound() public {
+        QueryCoordinatorStateRequest.Data memory req;
+        req.tx_id = abi.encodePacked(txID);
+
+        vm.expectRevert(abi.encodeWithSelector(CoordinatorStateNotFound.selector, txID));
+        harness.coordinatorState(req);
+    }
+}

--- a/test/DelegatedLogicHandler.t.sol
+++ b/test/DelegatedLogicHandler.t.sol
@@ -15,6 +15,7 @@ import {
 import {Account as AuthAccount, AuthType, TxAuthState} from "../src/proto/cross/core/auth/Auth.sol";
 import {Tx} from "../src/proto/cross/core/tx/Tx.sol";
 import {IbcCoreClientV1Height} from "../src/proto/ibc/core/client/v1/client.sol";
+import {CoordinatorState} from "../src/proto/cross/core/atomic/simple/AtomicSimple.sol";
 import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
 import {Height} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/Client.sol";
@@ -28,6 +29,7 @@ contract MockStore {
     struct TxStorage {
         mapping(bytes32 => MsgInitiateTxResponse.InitiateTxStatus) status;
         mapping(bytes32 => uint64) nonce;
+        mapping(bytes32 => CoordinatorState.Data) coordStates;
         uint256 handlePacketCount;
         uint256 handleAckCount;
         uint256 handleTimeoutCount;
@@ -110,6 +112,10 @@ contract MockTxManager is ITxManager, MockStore {
         return true;
     }
 
+    function getCoordinatorState(bytes32 txID) external view override returns (CoordinatorState.Data memory) {
+        return txStorage.coordStates[txID];
+    }
+
     function handlePacket(Packet calldata) external override returns (bytes memory) {
         ++txStorage.handlePacketCount;
         return hex"1234";
@@ -185,6 +191,10 @@ contract DelegatedLogicHandlerHarness is DelegatedLogicHandler, MockStore {
         return _isTxRecorded(txID);
     }
 
+    function exposed_getCoordinatorState(bytes32 txID) public returns (CoordinatorState.Data memory) {
+        return _getCoordinatorState(txID);
+    }
+
     function exposed_handlePacket(Packet calldata packet) public returns (bytes memory) {
         return _handlePacket(packet);
     }
@@ -209,7 +219,7 @@ contract DelegatedLogicHandlerHarness is DelegatedLogicHandler, MockStore {
         return val;
     }
 
-    function revert(string calldata reason) external pure {
+    function triggerRevert(string calldata reason) external pure {
         revert(reason);
     }
 
@@ -221,6 +231,10 @@ contract DelegatedLogicHandlerHarness is DelegatedLogicHandler, MockStore {
 
     function stateChange(uint256 val) external {
         internalState = val;
+    }
+
+    function setCoordState(bytes32 txID, CoordinatorState.Data calldata data) external {
+        txStorage.coordStates[txID] = data;
     }
 
     function readAuth_callCount(bytes32 txID) public view returns (uint256) {
@@ -380,6 +394,19 @@ contract DelegatedLogicHandlerTest is Test, ICrossError {
         assertEq(harness.readTx_handleTimeoutCount(), 1, "handleTimeout call count mismatch");
     }
 
+    function test_getCoordinatorState_DelegatesToTxManager() public {
+        CoordinatorState.Data memory expected;
+        expected.commit_protocol = Tx.CommitProtocol.COMMIT_PROTOCOL_SIMPLE;
+        expected.phase = CoordinatorState.CoordinatorPhase.COORDINATOR_PHASE_PREPARE;
+        harness.setCoordState(txID, expected);
+
+        vm.expectCall(address(mockTx), abi.encodeWithSelector(ITxManager.getCoordinatorState.selector, txID));
+        CoordinatorState.Data memory actual = harness.exposed_getCoordinatorState(txID);
+
+        assertEq(uint256(actual.commit_protocol), uint256(expected.commit_protocol), "Commit protocol mismatch");
+        assertEq(uint256(actual.phase), uint256(expected.phase), "Phase mismatch");
+    }
+
     function test_delegateWithData_SucceedsAndReturnsData() public {
         MockSuccessContract successMock = new MockSuccessContract();
 
@@ -423,7 +450,7 @@ contract DelegatedLogicHandlerTest is Test, ICrossError {
 
     function test_staticCallSelf_RevertsIf_TargetReverts() public {
         string memory reason = "StaticCallError";
-        bytes memory callData = abi.encodeWithSelector(harness.revert.selector, reason);
+        bytes memory callData = abi.encodeWithSelector(harness.triggerRevert.selector, reason);
 
         vm.expectRevert(bytes(reason));
         harness.exposed_staticCallSelf(callData);
@@ -460,5 +487,11 @@ contract DelegatedLogicHandlerTest is Test, ICrossError {
         // Test: __isTxRecorded
         vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, address(this)));
         harness.__isTxRecorded(txID);
+    }
+
+    function test_getCoordinatorState_RevertIf_CalledExternally() public {
+        // Test: __getCoordinatorState
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, address(this)));
+        harness.__getCoordinatorState(txID);
     }
 }

--- a/test/Initiator.t.sol
+++ b/test/Initiator.t.sol
@@ -20,6 +20,7 @@ import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/pr
 import {Tx} from "../src/proto/cross/core/tx/Tx.sol";
 import {IbcCoreClientV1Height} from "../src/proto/ibc/core/client/v1/client.sol";
 import {ChannelInfo} from "../src/proto/cross/core/xcc/XCC.sol";
+import {CoordinatorState} from "../src/proto/cross/core/atomic/simple/AtomicSimple.sol";
 
 contract MockTxManager is TxManagerBase {
     mapping(bytes32 => bool) public txExists;
@@ -41,6 +42,19 @@ contract MockTxManager is TxManagerBase {
 
     function _isTxRecorded(bytes32 txID) internal view virtual override returns (bool) {
         return txExists[txID];
+    }
+
+    function _getCoordinatorState(
+        bytes32 /*txID*/
+    )
+        internal
+        view
+        virtual
+        override
+        returns (CoordinatorState.Data memory)
+    {
+        CoordinatorState.Data memory dummy;
+        return dummy;
     }
 
     function setTxExists(bytes32 txID, bool exists) public {

--- a/test/TxManager.t.sol
+++ b/test/TxManager.t.sol
@@ -12,11 +12,12 @@ import {
     Link,
     ReturnValue
 } from "../src/proto/cross/core/initiator/Initiator.sol";
+import {ICrossError} from "../src/core/ICrossError.sol";
 import {Account as AuthAccount, AuthType} from "../src/proto/cross/core/auth/Auth.sol";
 import {Tx} from "../src/proto/cross/core/tx/Tx.sol";
 import {IbcCoreClientV1Height} from "../src/proto/ibc/core/client/v1/client.sol";
+import {CoordinatorState} from "../src/proto/cross/core/atomic/simple/AtomicSimple.sol";
 import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
-import {ICrossError} from "../src/core/ICrossError.sol";
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
 import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 import {IContractModule} from "../src/core/IContractModule.sol";
@@ -81,9 +82,14 @@ contract TxManagerHarness is TxManager {
         Packet memory p;
         return getModule(p);
     }
+
+    function setCoordinatorState(bytes32 txID, CoordinatorState.Data calldata data) public {
+        CrossStore.CoordStorage storage s = _getCoordStorage();
+        s.states[txID] = data;
+    }
 }
 
-contract TxManagerTest is Test {
+contract TxManagerTest is Test, ICrossError {
     TxManagerHarness private harness;
     bytes32 private txID = keccak256("test_tx_id");
     MsgInitiateTx.Data private txMsg;
@@ -282,7 +288,7 @@ contract TxManagerTest is Test {
 
     function test_createTx_RevertWhen_TxAlreadyExists() public {
         harness.createTx(txID, txMsg); // First time
-        vm.expectRevert(abi.encodeWithSelector(ICrossError.TxAlreadyExists.selector, txID));
+        vm.expectRevert(abi.encodeWithSelector(TxAlreadyExists.selector, txID));
         harness.createTx(txID, txMsg); // Second time
     }
 
@@ -331,5 +337,23 @@ contract TxManagerTest is Test {
             uint256(MsgInitiateTxResponse.InitiateTxStatus.INITIATE_TX_STATUS_VERIFIED),
             "Status should be VERIFIED"
         );
+    }
+
+    function test_getCoordinatorState_ReturnsCorrectState() public {
+        CoordinatorState.Data memory expected;
+        expected.commit_protocol = Tx.CommitProtocol.COMMIT_PROTOCOL_SIMPLE;
+        expected.phase = CoordinatorState.CoordinatorPhase.COORDINATOR_PHASE_PREPARE;
+
+        harness.setCoordinatorState(txID, expected);
+
+        CoordinatorState.Data memory actual = harness.getCoordinatorState(txID);
+
+        assertEq(uint256(actual.commit_protocol), uint256(expected.commit_protocol), "Commit protocol mismatch");
+        assertEq(uint256(actual.phase), uint256(expected.phase), "Phase mismatch");
+    }
+
+    function test_getCoordinatorState_RevertsIfNotFound() public {
+        vm.expectRevert(abi.encodeWithSelector(CoordinatorStateNotFound.selector, txID));
+        harness.getCoordinatorState(txID);
     }
 }


### PR DESCRIPTION
- implmented Coordinator.sol and unit tests
- Adjusted `optimizer_runs` parameters as TxManager contract size exceeded the limit.

## Contract Size

```
╭------------------------------------------------------+------------------+-------------------+--------------------+---------------------╮
| Contract                                             | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
+========================================================================================================================================+
| CrossSimpleModule                                    | 15,057           | 16,955            | 9,519              | 32,197              |
|------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| TxAuthManager                                        | 5,420            | 5,447             | 19,156             | 43,705              |
|------------------------------------------------------+------------------+-------------------+--------------------+---------------------|
| TxManager                                            | 23,738           | 23,770            | 838                | 25,382              |
```