### PR TITLE
Refactor cross-chain events and introduce ICrossEvent interface

### DIFF
--- a/pkg/contract/crosssimplemodule/crosssimplemodule.go
+++ b/pkg/contract/crosssimplemodule/crosssimplemodule.go
@@ -47,6 +47,12 @@ type ChannelCounterpartyData struct {
 	ChannelId string
 }
 
+// ChannelInfoData is an auto generated low-level Go binding around an user-defined struct.
+type ChannelInfoData struct {
+	Port    string
+	Channel string
+}
+
 // ContractTransactionData is an auto generated low-level Go binding around an user-defined struct.
 type ContractTransactionData struct {
 	CrossChainChannel GoogleProtobufAnyData
@@ -54,6 +60,16 @@ type ContractTransactionData struct {
 	CallInfo          []byte
 	ReturnValue       ReturnValueData
 	Links             []LinkData
+}
+
+// CoordinatorStateData is an auto generated low-level Go binding around an user-defined struct.
+type CoordinatorStateData struct {
+	CommitProtocol uint8
+	Channels       []ChannelInfoData
+	Phase          uint8
+	Decision       uint8
+	ConfirmedTxs   []uint32
+	Acks           []uint32
 }
 
 // GoogleProtobufAnyData is an auto generated low-level Go binding around an user-defined struct.
@@ -178,6 +194,16 @@ type Packet struct {
 	TimeoutTimestamp   uint64
 }
 
+// QueryCoordinatorStateRequestData is an auto generated low-level Go binding around an user-defined struct.
+type QueryCoordinatorStateRequestData struct {
+	TxId []byte
+}
+
+// QueryCoordinatorStateResponseData is an auto generated low-level Go binding around an user-defined struct.
+type QueryCoordinatorStateResponseData struct {
+	CoodinatorState CoordinatorStateData
+}
+
 // QuerySelfXCCResponseData is an auto generated low-level Go binding around an user-defined struct.
 type QuerySelfXCCResponseData struct {
 	Xcc GoogleProtobufAnyData
@@ -205,7 +231,7 @@ type TxAuthStateData struct {
 
 // CrosssimplemoduleMetaData contains all meta data concerning the Crosssimplemodule contract.
 var CrosssimplemoduleMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"ibcHandler_\",\"type\":\"address\",\"internalType\":\"contractIIBCHandler\"},{\"name\":\"txAuthManager_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"txManager_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"module_\",\"type\":\"address\",\"internalType\":\"contractIContractModule\"},{\"name\":\"authTypeUrls_\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"authVerifiers_\",\"type\":\"address[]\",\"internalType\":\"contractIAuthExtensionVerifier[]\"},{\"name\":\"debugMode\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"CHAIN_ID_HASH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"IBC_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"TX_AUTH_MANAGER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"TX_MANAGER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"__getAuthState\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structTxAuthState.Data\",\"components\":[{\"name\":\"remaining_signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"__isCompletedAuth\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"__isTxRecorded\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"extSignTx\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structMsgExtSignTx.Data\",\"components\":[{\"name\":\"txID\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structMsgExtSignTxResponse.Data\",\"components\":[{\"name\":\"x\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initiateTx\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structMsgInitiateTx.Data\",\"components\":[{\"name\":\"chain_id\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"nonce\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"commit_protocol\",\"type\":\"uint8\",\"internalType\":\"enumTx.CommitProtocol\"},{\"name\":\"contract_transactions\",\"type\":\"tuple[]\",\"internalType\":\"structContractTransaction.Data[]\",\"components\":[{\"name\":\"cross_chain_channel\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]},{\"name\":\"call_info\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"return_value\",\"type\":\"tuple\",\"internalType\":\"structReturnValue.Data\",\"components\":[{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"links\",\"type\":\"tuple[]\",\"internalType\":\"structLink.Data[]\",\"components\":[{\"name\":\"src_index\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}]},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]},{\"name\":\"timeout_height\",\"type\":\"tuple\",\"internalType\":\"structIbcCoreClientV1Height.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeout_timestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[{\"name\":\"resp\",\"type\":\"tuple\",\"internalType\":\"structMsgInitiateTxResponse.Data\",\"components\":[{\"name\":\"txID\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"status\",\"type\":\"uint8\",\"internalType\":\"enumMsgInitiateTxResponse.InitiateTxStatus\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onAcknowledgementPacket\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanCloseConfirm\",\"inputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIIBCModule.MsgOnChanCloseConfirm\",\"components\":[{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanCloseInit\",\"inputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIIBCModule.MsgOnChanCloseInit\",\"components\":[{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanOpenAck\",\"inputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIIBCModule.MsgOnChanOpenAck\",\"components\":[{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"counterpartyVersion\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanOpenConfirm\",\"inputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIIBCModule.MsgOnChanOpenConfirm\",\"components\":[{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanOpenInit\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structIIBCModuleInitializer.MsgOnChanOpenInit\",\"components\":[{\"name\":\"order\",\"type\":\"uint8\",\"internalType\":\"enumChannel.Order\"},{\"name\":\"connectionHops\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"counterparty\",\"type\":\"tuple\",\"internalType\":\"structChannelCounterparty.Data\",\"components\":[{\"name\":\"port_id\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channel_id\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"name\":\"version\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[{\"name\":\"moduleAddr\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"version\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanOpenTry\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structIIBCModuleInitializer.MsgOnChanOpenTry\",\"components\":[{\"name\":\"order\",\"type\":\"uint8\",\"internalType\":\"enumChannel.Order\"},{\"name\":\"connectionHops\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"counterparty\",\"type\":\"tuple\",\"internalType\":\"structChannelCounterparty.Data\",\"components\":[{\"name\":\"port_id\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channel_id\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"name\":\"counterpartyVersion\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[{\"name\":\"moduleAddr\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"version\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onRecvPacket\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onTimeoutPacket\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"selfXCC\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structQuerySelfXCCResponse.Data\",\"components\":[{\"name\":\"xcc\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"signTx\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structMsgSignTx.Data\",\"components\":[{\"name\":\"txID\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"signers\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"},{\"name\":\"timeout_height\",\"type\":\"tuple\",\"internalType\":\"structIbcCoreClientV1Height.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeout_timestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structMsgSignTxResponse.Data\",\"components\":[{\"name\":\"tx_auth_completed\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"log\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceID\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"txAuthState\",\"inputs\":[{\"name\":\"req_\",\"type\":\"tuple\",\"internalType\":\"structQueryTxAuthStateRequest.Data\",\"components\":[{\"name\":\"txID\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"resp\",\"type\":\"tuple\",\"internalType\":\"structQueryTxAuthStateResponse.Data\",\"components\":[{\"name\":\"tx_auth_state\",\"type\":\"tuple\",\"internalType\":\"structTxAuthState.Data\",\"components\":[{\"name\":\"remaining_signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]}]}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TxInitiated\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"proposer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TxSigned\",\"inputs\":[{\"name\":\"signer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"txID\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"method\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumAuthType.AuthMode\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AckIsNotSuccess\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AllTransactionsConfirmed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ArrayLengthMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AuthAlreadyCompleted\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AuthModeMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AuthStateAlreadyInitialized\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"ChannelNotFound\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorPhaseNotPrepare\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorStateInconsistent\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorStateNotFound\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"CoordinatorTxStatusNotPrepare\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DelegateCallFailed\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"EmptyTypeUrl\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IDNotFound\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"InvalidSignersLength\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidTxIDLength\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LinksNotSupported\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MessageTimeoutHeight\",\"inputs\":[{\"name\":\"blockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"timeoutVersionHeight\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"type\":\"error\",\"name\":\"MessageTimeoutTimestamp\",\"inputs\":[{\"name\":\"blockTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"type\":\"error\",\"name\":\"ModuleAlreadyInitialized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ModuleNotInitialized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotImplemented\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"PayloadDecodeFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SignatureVerificationFailed\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"SignerCountMismatch\",\"inputs\":[{\"name\":\"signerCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"signatureCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"SignerMustEqualSender\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"StaticCallFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TPCNotImplemented\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TooManySigners\",\"inputs\":[{\"name\":\"got\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"Tx0MustBeForSelfChain\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TxAlreadyExists\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"TxAlreadyVerified\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"TxIDAlreadyExists\",\"inputs\":[{\"name\":\"txIDHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnauthorizedCaller\",\"inputs\":[{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UnexpectedChainID\",\"inputs\":[{\"name\":\"expectedHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"gotHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnexpectedCommitStatus\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedReturnValue\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedSourceChannel\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedTypeURL\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnknownCommitProtocol\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"VerifierNotFound\",\"inputs\":[{\"name\":\"typeUrl\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"VerifierReturnedFalse\",\"inputs\":[{\"name\":\"txIDHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"typeUrl\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"ZeroAddressVerifier\",\"inputs\":[]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"ibcHandler_\",\"type\":\"address\",\"internalType\":\"contractIIBCHandler\"},{\"name\":\"txAuthManager_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"txManager_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"module_\",\"type\":\"address\",\"internalType\":\"contractIContractModule\"},{\"name\":\"authTypeUrls_\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"authVerifiers_\",\"type\":\"address[]\",\"internalType\":\"contractIAuthExtensionVerifier[]\"},{\"name\":\"debugMode\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"CHAIN_ID_HASH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"IBC_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"TX_AUTH_MANAGER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"TX_MANAGER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"__getAuthState\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structTxAuthState.Data\",\"components\":[{\"name\":\"remaining_signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"__getCoordinatorState\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structCoordinatorState.Data\",\"components\":[{\"name\":\"commit_protocol\",\"type\":\"uint8\",\"internalType\":\"enumTx.CommitProtocol\"},{\"name\":\"channels\",\"type\":\"tuple[]\",\"internalType\":\"structChannelInfo.Data[]\",\"components\":[{\"name\":\"port\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channel\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"name\":\"phase\",\"type\":\"uint8\",\"internalType\":\"enumCoordinatorState.CoordinatorPhase\"},{\"name\":\"decision\",\"type\":\"uint8\",\"internalType\":\"enumCoordinatorState.CoordinatorDecision\"},{\"name\":\"confirmed_txs\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"},{\"name\":\"acks\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"__isCompletedAuth\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"__isTxRecorded\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"coordinatorState\",\"inputs\":[{\"name\":\"req\",\"type\":\"tuple\",\"internalType\":\"structQueryCoordinatorStateRequest.Data\",\"components\":[{\"name\":\"tx_id\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structQueryCoordinatorStateResponse.Data\",\"components\":[{\"name\":\"coodinator_state\",\"type\":\"tuple\",\"internalType\":\"structCoordinatorState.Data\",\"components\":[{\"name\":\"commit_protocol\",\"type\":\"uint8\",\"internalType\":\"enumTx.CommitProtocol\"},{\"name\":\"channels\",\"type\":\"tuple[]\",\"internalType\":\"structChannelInfo.Data[]\",\"components\":[{\"name\":\"port\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channel\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"name\":\"phase\",\"type\":\"uint8\",\"internalType\":\"enumCoordinatorState.CoordinatorPhase\"},{\"name\":\"decision\",\"type\":\"uint8\",\"internalType\":\"enumCoordinatorState.CoordinatorDecision\"},{\"name\":\"confirmed_txs\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"},{\"name\":\"acks\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"extSignTx\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structMsgExtSignTx.Data\",\"components\":[{\"name\":\"txID\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structMsgExtSignTxResponse.Data\",\"components\":[{\"name\":\"x\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initiateTx\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structMsgInitiateTx.Data\",\"components\":[{\"name\":\"chain_id\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"nonce\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"commit_protocol\",\"type\":\"uint8\",\"internalType\":\"enumTx.CommitProtocol\"},{\"name\":\"contract_transactions\",\"type\":\"tuple[]\",\"internalType\":\"structContractTransaction.Data[]\",\"components\":[{\"name\":\"cross_chain_channel\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]},{\"name\":\"call_info\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"return_value\",\"type\":\"tuple\",\"internalType\":\"structReturnValue.Data\",\"components\":[{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"links\",\"type\":\"tuple[]\",\"internalType\":\"structLink.Data[]\",\"components\":[{\"name\":\"src_index\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}]},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]},{\"name\":\"timeout_height\",\"type\":\"tuple\",\"internalType\":\"structIbcCoreClientV1Height.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeout_timestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[{\"name\":\"resp\",\"type\":\"tuple\",\"internalType\":\"structMsgInitiateTxResponse.Data\",\"components\":[{\"name\":\"txID\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"status\",\"type\":\"uint8\",\"internalType\":\"enumMsgInitiateTxResponse.InitiateTxStatus\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onAcknowledgementPacket\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanCloseConfirm\",\"inputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIIBCModule.MsgOnChanCloseConfirm\",\"components\":[{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanCloseInit\",\"inputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIIBCModule.MsgOnChanCloseInit\",\"components\":[{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanOpenAck\",\"inputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIIBCModule.MsgOnChanOpenAck\",\"components\":[{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"counterpartyVersion\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanOpenConfirm\",\"inputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIIBCModule.MsgOnChanOpenConfirm\",\"components\":[{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanOpenInit\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structIIBCModuleInitializer.MsgOnChanOpenInit\",\"components\":[{\"name\":\"order\",\"type\":\"uint8\",\"internalType\":\"enumChannel.Order\"},{\"name\":\"connectionHops\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"counterparty\",\"type\":\"tuple\",\"internalType\":\"structChannelCounterparty.Data\",\"components\":[{\"name\":\"port_id\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channel_id\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"name\":\"version\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[{\"name\":\"moduleAddr\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"version\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onChanOpenTry\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structIIBCModuleInitializer.MsgOnChanOpenTry\",\"components\":[{\"name\":\"order\",\"type\":\"uint8\",\"internalType\":\"enumChannel.Order\"},{\"name\":\"connectionHops\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"portId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channelId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"counterparty\",\"type\":\"tuple\",\"internalType\":\"structChannelCounterparty.Data\",\"components\":[{\"name\":\"port_id\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channel_id\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"name\":\"counterpartyVersion\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[{\"name\":\"moduleAddr\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"version\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onRecvPacket\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onTimeoutPacket\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"selfXCC\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structQuerySelfXCCResponse.Data\",\"components\":[{\"name\":\"xcc\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"signTx\",\"inputs\":[{\"name\":\"msg_\",\"type\":\"tuple\",\"internalType\":\"structMsgSignTx.Data\",\"components\":[{\"name\":\"txID\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"signers\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"},{\"name\":\"timeout_height\",\"type\":\"tuple\",\"internalType\":\"structIbcCoreClientV1Height.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeout_timestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structMsgSignTxResponse.Data\",\"components\":[{\"name\":\"tx_auth_completed\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"log\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceID\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"txAuthState\",\"inputs\":[{\"name\":\"req_\",\"type\":\"tuple\",\"internalType\":\"structQueryTxAuthStateRequest.Data\",\"components\":[{\"name\":\"txID\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"resp\",\"type\":\"tuple\",\"internalType\":\"structQueryTxAuthStateResponse.Data\",\"components\":[{\"name\":\"tx_auth_state\",\"type\":\"tuple\",\"internalType\":\"structTxAuthState.Data\",\"components\":[{\"name\":\"remaining_signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]}]}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"OnAbort\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"txIndex\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OnCommit\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"txIndex\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OnContractCommitImmediately\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"txIndex\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"uint8\"},{\"name\":\"success\",\"type\":\"bool\",\"indexed\":true,\"internalType\":\"bool\"},{\"name\":\"ret\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TxInitiated\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"proposer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TxSigned\",\"inputs\":[{\"name\":\"signer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"txID\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"method\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumAuthType.AuthMode\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AckIsNotSuccess\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AllTransactionsConfirmed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ArrayLengthMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AuthAlreadyCompleted\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AuthModeMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AuthStateAlreadyInitialized\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"ChannelNotFound\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorPhaseNotPrepare\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorStateInconsistent\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorStateNotFound\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"CoordinatorTxStatusNotPrepare\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DelegateCallFailed\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"EmptyTypeUrl\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IDNotFound\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"InvalidSignersLength\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidTxIDLength\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LinksNotSupported\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MessageTimeoutHeight\",\"inputs\":[{\"name\":\"blockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"timeoutVersionHeight\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"type\":\"error\",\"name\":\"MessageTimeoutTimestamp\",\"inputs\":[{\"name\":\"blockTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"type\":\"error\",\"name\":\"ModuleAlreadyInitialized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ModuleNotInitialized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotImplemented\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"PayloadDecodeFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SignatureVerificationFailed\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"SignerCountMismatch\",\"inputs\":[{\"name\":\"signerCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"signatureCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"SignerMustEqualSender\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"StaticCallFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TPCNotImplemented\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TooManySigners\",\"inputs\":[{\"name\":\"got\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"Tx0MustBeForSelfChain\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TxAlreadyExists\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"TxAlreadyVerified\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"TxIDAlreadyExists\",\"inputs\":[{\"name\":\"txIDHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnauthorizedCaller\",\"inputs\":[{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UnexpectedChainID\",\"inputs\":[{\"name\":\"expectedHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"gotHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnexpectedCommitStatus\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedReturnValue\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedSourceChannel\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedTypeURL\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnknownCommitProtocol\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"VerifierNotFound\",\"inputs\":[{\"name\":\"typeUrl\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"VerifierReturnedFalse\",\"inputs\":[{\"name\":\"txIDHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"typeUrl\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"ZeroAddressVerifier\",\"inputs\":[]}]",
 }
 
 // CrosssimplemoduleABI is the input ABI used to generate the binding from.
@@ -509,6 +535,37 @@ func (_Crosssimplemodule *CrosssimplemoduleCallerSession) TXMANAGER() (common.Ad
 	return _Crosssimplemodule.Contract.TXMANAGER(&_Crosssimplemodule.CallOpts)
 }
 
+// CoordinatorState is a free data retrieval call binding the contract method 0x9c1c9c9d.
+//
+// Solidity: function coordinatorState((bytes) req) view returns(((uint8,(string,string)[],uint8,uint8,uint32[],uint32[])))
+func (_Crosssimplemodule *CrosssimplemoduleCaller) CoordinatorState(opts *bind.CallOpts, req QueryCoordinatorStateRequestData) (QueryCoordinatorStateResponseData, error) {
+	var out []interface{}
+	err := _Crosssimplemodule.contract.Call(opts, &out, "coordinatorState", req)
+
+	if err != nil {
+		return *new(QueryCoordinatorStateResponseData), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(QueryCoordinatorStateResponseData)).(*QueryCoordinatorStateResponseData)
+
+	return out0, err
+
+}
+
+// CoordinatorState is a free data retrieval call binding the contract method 0x9c1c9c9d.
+//
+// Solidity: function coordinatorState((bytes) req) view returns(((uint8,(string,string)[],uint8,uint8,uint32[],uint32[])))
+func (_Crosssimplemodule *CrosssimplemoduleSession) CoordinatorState(req QueryCoordinatorStateRequestData) (QueryCoordinatorStateResponseData, error) {
+	return _Crosssimplemodule.Contract.CoordinatorState(&_Crosssimplemodule.CallOpts, req)
+}
+
+// CoordinatorState is a free data retrieval call binding the contract method 0x9c1c9c9d.
+//
+// Solidity: function coordinatorState((bytes) req) view returns(((uint8,(string,string)[],uint8,uint8,uint32[],uint32[])))
+func (_Crosssimplemodule *CrosssimplemoduleCallerSession) CoordinatorState(req QueryCoordinatorStateRequestData) (QueryCoordinatorStateResponseData, error) {
+	return _Crosssimplemodule.Contract.CoordinatorState(&_Crosssimplemodule.CallOpts, req)
+}
+
 // GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
 //
 // Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
@@ -652,6 +709,27 @@ func (_Crosssimplemodule *CrosssimplemoduleSession) GetAuthState(txID [32]byte) 
 // Solidity: function __getAuthState(bytes32 txID) returns(((bytes,(uint8,(string,bytes)))[]))
 func (_Crosssimplemodule *CrosssimplemoduleTransactorSession) GetAuthState(txID [32]byte) (*types.Transaction, error) {
 	return _Crosssimplemodule.Contract.GetAuthState(&_Crosssimplemodule.TransactOpts, txID)
+}
+
+// GetCoordinatorState is a paid mutator transaction binding the contract method 0x3a57f0d2.
+//
+// Solidity: function __getCoordinatorState(bytes32 txID) returns((uint8,(string,string)[],uint8,uint8,uint32[],uint32[]))
+func (_Crosssimplemodule *CrosssimplemoduleTransactor) GetCoordinatorState(opts *bind.TransactOpts, txID [32]byte) (*types.Transaction, error) {
+	return _Crosssimplemodule.contract.Transact(opts, "__getCoordinatorState", txID)
+}
+
+// GetCoordinatorState is a paid mutator transaction binding the contract method 0x3a57f0d2.
+//
+// Solidity: function __getCoordinatorState(bytes32 txID) returns((uint8,(string,string)[],uint8,uint8,uint32[],uint32[]))
+func (_Crosssimplemodule *CrosssimplemoduleSession) GetCoordinatorState(txID [32]byte) (*types.Transaction, error) {
+	return _Crosssimplemodule.Contract.GetCoordinatorState(&_Crosssimplemodule.TransactOpts, txID)
+}
+
+// GetCoordinatorState is a paid mutator transaction binding the contract method 0x3a57f0d2.
+//
+// Solidity: function __getCoordinatorState(bytes32 txID) returns((uint8,(string,string)[],uint8,uint8,uint32[],uint32[]))
+func (_Crosssimplemodule *CrosssimplemoduleTransactorSession) GetCoordinatorState(txID [32]byte) (*types.Transaction, error) {
+	return _Crosssimplemodule.Contract.GetCoordinatorState(&_Crosssimplemodule.TransactOpts, txID)
 }
 
 // IsCompletedAuth is a paid mutator transaction binding the contract method 0x8081e423.
@@ -1030,6 +1108,475 @@ func (_Crosssimplemodule *CrosssimplemoduleSession) TxAuthState(req_ QueryTxAuth
 // Solidity: function txAuthState((bytes) req_) returns((((bytes,(uint8,(string,bytes)))[])) resp)
 func (_Crosssimplemodule *CrosssimplemoduleTransactorSession) TxAuthState(req_ QueryTxAuthStateRequestData) (*types.Transaction, error) {
 	return _Crosssimplemodule.Contract.TxAuthState(&_Crosssimplemodule.TransactOpts, req_)
+}
+
+// CrosssimplemoduleOnAbortIterator is returned from FilterOnAbort and is used to iterate over the raw logs and unpacked data for OnAbort events raised by the Crosssimplemodule contract.
+type CrosssimplemoduleOnAbortIterator struct {
+	Event *CrosssimplemoduleOnAbort // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CrosssimplemoduleOnAbortIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CrosssimplemoduleOnAbort)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CrosssimplemoduleOnAbort)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CrosssimplemoduleOnAbortIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CrosssimplemoduleOnAbortIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CrosssimplemoduleOnAbort represents a OnAbort event raised by the Crosssimplemodule contract.
+type CrosssimplemoduleOnAbort struct {
+	TxID    common.Hash
+	TxIndex uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterOnAbort is a free log retrieval operation binding the contract event 0x250bcd3f1f48512b15dbba0fb804f06878f25675cc2381898c392169d814a6f1.
+//
+// Solidity: event OnAbort(bytes indexed txID, uint8 indexed txIndex)
+func (_Crosssimplemodule *CrosssimplemoduleFilterer) FilterOnAbort(opts *bind.FilterOpts, txID [][]byte, txIndex []uint8) (*CrosssimplemoduleOnAbortIterator, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+
+	logs, sub, err := _Crosssimplemodule.contract.FilterLogs(opts, "OnAbort", txIDRule, txIndexRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CrosssimplemoduleOnAbortIterator{contract: _Crosssimplemodule.contract, event: "OnAbort", logs: logs, sub: sub}, nil
+}
+
+// WatchOnAbort is a free log subscription operation binding the contract event 0x250bcd3f1f48512b15dbba0fb804f06878f25675cc2381898c392169d814a6f1.
+//
+// Solidity: event OnAbort(bytes indexed txID, uint8 indexed txIndex)
+func (_Crosssimplemodule *CrosssimplemoduleFilterer) WatchOnAbort(opts *bind.WatchOpts, sink chan<- *CrosssimplemoduleOnAbort, txID [][]byte, txIndex []uint8) (event.Subscription, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+
+	logs, sub, err := _Crosssimplemodule.contract.WatchLogs(opts, "OnAbort", txIDRule, txIndexRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CrosssimplemoduleOnAbort)
+				if err := _Crosssimplemodule.contract.UnpackLog(event, "OnAbort", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOnAbort is a log parse operation binding the contract event 0x250bcd3f1f48512b15dbba0fb804f06878f25675cc2381898c392169d814a6f1.
+//
+// Solidity: event OnAbort(bytes indexed txID, uint8 indexed txIndex)
+func (_Crosssimplemodule *CrosssimplemoduleFilterer) ParseOnAbort(log types.Log) (*CrosssimplemoduleOnAbort, error) {
+	event := new(CrosssimplemoduleOnAbort)
+	if err := _Crosssimplemodule.contract.UnpackLog(event, "OnAbort", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CrosssimplemoduleOnCommitIterator is returned from FilterOnCommit and is used to iterate over the raw logs and unpacked data for OnCommit events raised by the Crosssimplemodule contract.
+type CrosssimplemoduleOnCommitIterator struct {
+	Event *CrosssimplemoduleOnCommit // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CrosssimplemoduleOnCommitIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CrosssimplemoduleOnCommit)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CrosssimplemoduleOnCommit)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CrosssimplemoduleOnCommitIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CrosssimplemoduleOnCommitIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CrosssimplemoduleOnCommit represents a OnCommit event raised by the Crosssimplemodule contract.
+type CrosssimplemoduleOnCommit struct {
+	TxID    common.Hash
+	TxIndex uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterOnCommit is a free log retrieval operation binding the contract event 0x7aaf0b63467fb40eac34c045248842f31e4e1edff7f0dd939f7ddeeddd83adc0.
+//
+// Solidity: event OnCommit(bytes indexed txID, uint8 indexed txIndex)
+func (_Crosssimplemodule *CrosssimplemoduleFilterer) FilterOnCommit(opts *bind.FilterOpts, txID [][]byte, txIndex []uint8) (*CrosssimplemoduleOnCommitIterator, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+
+	logs, sub, err := _Crosssimplemodule.contract.FilterLogs(opts, "OnCommit", txIDRule, txIndexRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CrosssimplemoduleOnCommitIterator{contract: _Crosssimplemodule.contract, event: "OnCommit", logs: logs, sub: sub}, nil
+}
+
+// WatchOnCommit is a free log subscription operation binding the contract event 0x7aaf0b63467fb40eac34c045248842f31e4e1edff7f0dd939f7ddeeddd83adc0.
+//
+// Solidity: event OnCommit(bytes indexed txID, uint8 indexed txIndex)
+func (_Crosssimplemodule *CrosssimplemoduleFilterer) WatchOnCommit(opts *bind.WatchOpts, sink chan<- *CrosssimplemoduleOnCommit, txID [][]byte, txIndex []uint8) (event.Subscription, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+
+	logs, sub, err := _Crosssimplemodule.contract.WatchLogs(opts, "OnCommit", txIDRule, txIndexRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CrosssimplemoduleOnCommit)
+				if err := _Crosssimplemodule.contract.UnpackLog(event, "OnCommit", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOnCommit is a log parse operation binding the contract event 0x7aaf0b63467fb40eac34c045248842f31e4e1edff7f0dd939f7ddeeddd83adc0.
+//
+// Solidity: event OnCommit(bytes indexed txID, uint8 indexed txIndex)
+func (_Crosssimplemodule *CrosssimplemoduleFilterer) ParseOnCommit(log types.Log) (*CrosssimplemoduleOnCommit, error) {
+	event := new(CrosssimplemoduleOnCommit)
+	if err := _Crosssimplemodule.contract.UnpackLog(event, "OnCommit", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// CrosssimplemoduleOnContractCommitImmediatelyIterator is returned from FilterOnContractCommitImmediately and is used to iterate over the raw logs and unpacked data for OnContractCommitImmediately events raised by the Crosssimplemodule contract.
+type CrosssimplemoduleOnContractCommitImmediatelyIterator struct {
+	Event *CrosssimplemoduleOnContractCommitImmediately // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *CrosssimplemoduleOnContractCommitImmediatelyIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(CrosssimplemoduleOnContractCommitImmediately)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(CrosssimplemoduleOnContractCommitImmediately)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *CrosssimplemoduleOnContractCommitImmediatelyIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *CrosssimplemoduleOnContractCommitImmediatelyIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// CrosssimplemoduleOnContractCommitImmediately represents a OnContractCommitImmediately event raised by the Crosssimplemodule contract.
+type CrosssimplemoduleOnContractCommitImmediately struct {
+	TxID    common.Hash
+	TxIndex uint8
+	Success bool
+	Ret     []byte
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterOnContractCommitImmediately is a free log retrieval operation binding the contract event 0x7da7723d423258c97d02fba73c0951597dc48566af572d5cb8e2698c22102e61.
+//
+// Solidity: event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret)
+func (_Crosssimplemodule *CrosssimplemoduleFilterer) FilterOnContractCommitImmediately(opts *bind.FilterOpts, txID [][]byte, txIndex []uint8, success []bool) (*CrosssimplemoduleOnContractCommitImmediatelyIterator, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+	var successRule []interface{}
+	for _, successItem := range success {
+		successRule = append(successRule, successItem)
+	}
+
+	logs, sub, err := _Crosssimplemodule.contract.FilterLogs(opts, "OnContractCommitImmediately", txIDRule, txIndexRule, successRule)
+	if err != nil {
+		return nil, err
+	}
+	return &CrosssimplemoduleOnContractCommitImmediatelyIterator{contract: _Crosssimplemodule.contract, event: "OnContractCommitImmediately", logs: logs, sub: sub}, nil
+}
+
+// WatchOnContractCommitImmediately is a free log subscription operation binding the contract event 0x7da7723d423258c97d02fba73c0951597dc48566af572d5cb8e2698c22102e61.
+//
+// Solidity: event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret)
+func (_Crosssimplemodule *CrosssimplemoduleFilterer) WatchOnContractCommitImmediately(opts *bind.WatchOpts, sink chan<- *CrosssimplemoduleOnContractCommitImmediately, txID [][]byte, txIndex []uint8, success []bool) (event.Subscription, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+	var successRule []interface{}
+	for _, successItem := range success {
+		successRule = append(successRule, successItem)
+	}
+
+	logs, sub, err := _Crosssimplemodule.contract.WatchLogs(opts, "OnContractCommitImmediately", txIDRule, txIndexRule, successRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(CrosssimplemoduleOnContractCommitImmediately)
+				if err := _Crosssimplemodule.contract.UnpackLog(event, "OnContractCommitImmediately", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOnContractCommitImmediately is a log parse operation binding the contract event 0x7da7723d423258c97d02fba73c0951597dc48566af572d5cb8e2698c22102e61.
+//
+// Solidity: event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret)
+func (_Crosssimplemodule *CrosssimplemoduleFilterer) ParseOnContractCommitImmediately(log types.Log) (*CrosssimplemoduleOnContractCommitImmediately, error) {
+	event := new(CrosssimplemoduleOnContractCommitImmediately)
+	if err := _Crosssimplemodule.contract.UnpackLog(event, "OnContractCommitImmediately", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
 }
 
 // CrosssimplemoduleRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the Crosssimplemodule contract.

--- a/pkg/contract/txmanager/txmanager.go
+++ b/pkg/contract/txmanager/txmanager.go
@@ -41,6 +41,12 @@ type AuthTypeData struct {
 	Option GoogleProtobufAnyData
 }
 
+// ChannelInfoData is an auto generated low-level Go binding around an user-defined struct.
+type ChannelInfoData struct {
+	Port    string
+	Channel string
+}
+
 // ContractTransactionData is an auto generated low-level Go binding around an user-defined struct.
 type ContractTransactionData struct {
 	CrossChainChannel GoogleProtobufAnyData
@@ -48,6 +54,16 @@ type ContractTransactionData struct {
 	CallInfo          []byte
 	ReturnValue       ReturnValueData
 	Links             []LinkData
+}
+
+// CoordinatorStateData is an auto generated low-level Go binding around an user-defined struct.
+type CoordinatorStateData struct {
+	CommitProtocol uint8
+	Channels       []ChannelInfoData
+	Phase          uint8
+	Decision       uint8
+	ConfirmedTxs   []uint32
+	Acks           []uint32
 }
 
 // GoogleProtobufAnyData is an auto generated low-level Go binding around an user-defined struct.
@@ -103,7 +119,7 @@ type ReturnValueData struct {
 
 // TxmanagerMetaData contains all meta data concerning the Txmanager contract.
 var TxmanagerMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"function\",\"name\":\"createTx\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"src\",\"type\":\"tuple\",\"internalType\":\"structMsgInitiateTx.Data\",\"components\":[{\"name\":\"chain_id\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"nonce\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"commit_protocol\",\"type\":\"uint8\",\"internalType\":\"enumTx.CommitProtocol\"},{\"name\":\"contract_transactions\",\"type\":\"tuple[]\",\"internalType\":\"structContractTransaction.Data[]\",\"components\":[{\"name\":\"cross_chain_channel\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]},{\"name\":\"call_info\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"return_value\",\"type\":\"tuple\",\"internalType\":\"structReturnValue.Data\",\"components\":[{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"links\",\"type\":\"tuple[]\",\"internalType\":\"structLink.Data[]\",\"components\":[{\"name\":\"src_index\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}]},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]},{\"name\":\"timeout_height\",\"type\":\"tuple\",\"internalType\":\"structIbcCoreClientV1Height.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeout_timestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getPacketAcknowledgementCall\",\"inputs\":[{\"name\":\"status\",\"type\":\"uint8\",\"internalType\":\"enumPacketAcknowledgementCall.CommitStatus\"}],\"outputs\":[{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"handleAcknowledgement\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"handlePacket\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"handleTimeout\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"handler_\",\"type\":\"address\",\"internalType\":\"contractIIBCHandler\"},{\"name\":\"module_\",\"type\":\"address\",\"internalType\":\"contractIContractModule\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isTxRecorded\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"runTxIfCompleted\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OnContractCall\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"txIndex\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"uint8\"},{\"name\":\"success\",\"type\":\"bool\",\"indexed\":true,\"internalType\":\"bool\"},{\"name\":\"ret\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AckIsNotSuccess\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AllTransactionsConfirmed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ArrayLengthMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AuthAlreadyCompleted\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AuthModeMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AuthStateAlreadyInitialized\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"ChannelNotFound\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorPhaseNotPrepare\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorStateInconsistent\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorStateNotFound\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"CoordinatorTxStatusNotPrepare\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DelegateCallFailed\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"EmptyTypeUrl\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IDNotFound\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidSignersLength\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidTxIDLength\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LinksNotSupported\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MessageTimeoutHeight\",\"inputs\":[{\"name\":\"blockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"timeoutVersionHeight\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"type\":\"error\",\"name\":\"MessageTimeoutTimestamp\",\"inputs\":[{\"name\":\"blockTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"type\":\"error\",\"name\":\"ModuleAlreadyInitialized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ModuleNotInitialized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotImplemented\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"PayloadDecodeFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SignatureVerificationFailed\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"SignerCountMismatch\",\"inputs\":[{\"name\":\"signerCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"signatureCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"SignerMustEqualSender\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"StaticCallFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TPCNotImplemented\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TooManySigners\",\"inputs\":[{\"name\":\"got\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"Tx0MustBeForSelfChain\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TxAlreadyExists\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"TxAlreadyVerified\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"TxIDAlreadyExists\",\"inputs\":[{\"name\":\"txIDHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnauthorizedCaller\",\"inputs\":[{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UnexpectedChainID\",\"inputs\":[{\"name\":\"expectedHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"gotHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnexpectedCommitStatus\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedReturnValue\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedSourceChannel\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedTypeURL\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnknownCommitProtocol\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"VerifierNotFound\",\"inputs\":[{\"name\":\"typeUrl\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"VerifierReturnedFalse\",\"inputs\":[{\"name\":\"txIDHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"typeUrl\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"ZeroAddressVerifier\",\"inputs\":[]}]",
+	ABI: "[{\"type\":\"function\",\"name\":\"createTx\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"src\",\"type\":\"tuple\",\"internalType\":\"structMsgInitiateTx.Data\",\"components\":[{\"name\":\"chain_id\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"nonce\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"commit_protocol\",\"type\":\"uint8\",\"internalType\":\"enumTx.CommitProtocol\"},{\"name\":\"contract_transactions\",\"type\":\"tuple[]\",\"internalType\":\"structContractTransaction.Data[]\",\"components\":[{\"name\":\"cross_chain_channel\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]},{\"name\":\"call_info\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"return_value\",\"type\":\"tuple\",\"internalType\":\"structReturnValue.Data\",\"components\":[{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"links\",\"type\":\"tuple[]\",\"internalType\":\"structLink.Data[]\",\"components\":[{\"name\":\"src_index\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}]},{\"name\":\"signers\",\"type\":\"tuple[]\",\"internalType\":\"structAccount.Data[]\",\"components\":[{\"name\":\"id\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"auth_type\",\"type\":\"tuple\",\"internalType\":\"structAuthType.Data\",\"components\":[{\"name\":\"mode\",\"type\":\"uint8\",\"internalType\":\"enumAuthType.AuthMode\"},{\"name\":\"option\",\"type\":\"tuple\",\"internalType\":\"structGoogleProtobufAny.Data\",\"components\":[{\"name\":\"type_url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"value\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]}]},{\"name\":\"timeout_height\",\"type\":\"tuple\",\"internalType\":\"structIbcCoreClientV1Height.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeout_timestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getCoordinatorState\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structCoordinatorState.Data\",\"components\":[{\"name\":\"commit_protocol\",\"type\":\"uint8\",\"internalType\":\"enumTx.CommitProtocol\"},{\"name\":\"channels\",\"type\":\"tuple[]\",\"internalType\":\"structChannelInfo.Data[]\",\"components\":[{\"name\":\"port\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"channel\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"name\":\"phase\",\"type\":\"uint8\",\"internalType\":\"enumCoordinatorState.CoordinatorPhase\"},{\"name\":\"decision\",\"type\":\"uint8\",\"internalType\":\"enumCoordinatorState.CoordinatorDecision\"},{\"name\":\"confirmed_txs\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"},{\"name\":\"acks\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getPacketAcknowledgementCall\",\"inputs\":[{\"name\":\"status\",\"type\":\"uint8\",\"internalType\":\"enumPacketAcknowledgementCall.CommitStatus\"}],\"outputs\":[{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"handleAcknowledgement\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"handlePacket\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[{\"name\":\"acknowledgement\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"handleTimeout\",\"inputs\":[{\"name\":\"packet\",\"type\":\"tuple\",\"internalType\":\"structPacket\",\"components\":[{\"name\":\"sequence\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"sourcePort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"sourceChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationPort\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"destinationChannel\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"timeoutHeight\",\"type\":\"tuple\",\"internalType\":\"structHeight.Data\",\"components\":[{\"name\":\"revision_number\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"revision_height\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"handler_\",\"type\":\"address\",\"internalType\":\"contractIIBCHandler\"},{\"name\":\"module_\",\"type\":\"address\",\"internalType\":\"contractIContractModule\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isTxRecorded\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"runTxIfCompleted\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OnAbort\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"txIndex\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OnCommit\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"txIndex\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OnContractCommitImmediately\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"txIndex\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"uint8\"},{\"name\":\"success\",\"type\":\"bool\",\"indexed\":true,\"internalType\":\"bool\"},{\"name\":\"ret\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TxInitiated\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"proposer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TxSigned\",\"inputs\":[{\"name\":\"signer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"txID\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"method\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumAuthType.AuthMode\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AckIsNotSuccess\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AllTransactionsConfirmed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ArrayLengthMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AuthAlreadyCompleted\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AuthModeMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AuthStateAlreadyInitialized\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"ChannelNotFound\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorPhaseNotPrepare\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorStateInconsistent\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CoordinatorStateNotFound\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"CoordinatorTxStatusNotPrepare\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DelegateCallFailed\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"EmptyTypeUrl\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IDNotFound\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidSignersLength\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidTxIDLength\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LinksNotSupported\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MessageTimeoutHeight\",\"inputs\":[{\"name\":\"blockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"timeoutVersionHeight\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"type\":\"error\",\"name\":\"MessageTimeoutTimestamp\",\"inputs\":[{\"name\":\"blockTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"timeoutTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"type\":\"error\",\"name\":\"ModuleAlreadyInitialized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ModuleNotInitialized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotImplemented\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"PayloadDecodeFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SignatureVerificationFailed\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"SignerCountMismatch\",\"inputs\":[{\"name\":\"signerCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"signatureCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"SignerMustEqualSender\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"StaticCallFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TPCNotImplemented\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TooManySigners\",\"inputs\":[{\"name\":\"got\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"Tx0MustBeForSelfChain\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TxAlreadyExists\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"TxAlreadyVerified\",\"inputs\":[{\"name\":\"txID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"TxIDAlreadyExists\",\"inputs\":[{\"name\":\"txIDHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnauthorizedCaller\",\"inputs\":[{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UnexpectedChainID\",\"inputs\":[{\"name\":\"expectedHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"gotHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnexpectedCommitStatus\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedReturnValue\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedSourceChannel\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnexpectedTypeURL\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnknownCommitProtocol\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"VerifierNotFound\",\"inputs\":[{\"name\":\"typeUrl\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"VerifierReturnedFalse\",\"inputs\":[{\"name\":\"txIDHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"typeUrl\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"ZeroAddressVerifier\",\"inputs\":[]}]",
 }
 
 // TxmanagerABI is the input ABI used to generate the binding from.
@@ -250,6 +266,37 @@ func (_Txmanager *TxmanagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*ty
 // Transact invokes the (paid) contract method with params as input values.
 func (_Txmanager *TxmanagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
 	return _Txmanager.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetCoordinatorState is a free data retrieval call binding the contract method 0xf8b89d89.
+//
+// Solidity: function getCoordinatorState(bytes32 txID) view returns((uint8,(string,string)[],uint8,uint8,uint32[],uint32[]))
+func (_Txmanager *TxmanagerCaller) GetCoordinatorState(opts *bind.CallOpts, txID [32]byte) (CoordinatorStateData, error) {
+	var out []interface{}
+	err := _Txmanager.contract.Call(opts, &out, "getCoordinatorState", txID)
+
+	if err != nil {
+		return *new(CoordinatorStateData), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(CoordinatorStateData)).(*CoordinatorStateData)
+
+	return out0, err
+
+}
+
+// GetCoordinatorState is a free data retrieval call binding the contract method 0xf8b89d89.
+//
+// Solidity: function getCoordinatorState(bytes32 txID) view returns((uint8,(string,string)[],uint8,uint8,uint32[],uint32[]))
+func (_Txmanager *TxmanagerSession) GetCoordinatorState(txID [32]byte) (CoordinatorStateData, error) {
+	return _Txmanager.Contract.GetCoordinatorState(&_Txmanager.CallOpts, txID)
+}
+
+// GetCoordinatorState is a free data retrieval call binding the contract method 0xf8b89d89.
+//
+// Solidity: function getCoordinatorState(bytes32 txID) view returns((uint8,(string,string)[],uint8,uint8,uint32[],uint32[]))
+func (_Txmanager *TxmanagerCallerSession) GetCoordinatorState(txID [32]byte) (CoordinatorStateData, error) {
+	return _Txmanager.Contract.GetCoordinatorState(&_Txmanager.CallOpts, txID)
 }
 
 // GetPacketAcknowledgementCall is a free data retrieval call binding the contract method 0x34a30a65.
@@ -574,9 +621,9 @@ func (_Txmanager *TxmanagerFilterer) ParseInitialized(log types.Log) (*Txmanager
 	return event, nil
 }
 
-// TxmanagerOnContractCallIterator is returned from FilterOnContractCall and is used to iterate over the raw logs and unpacked data for OnContractCall events raised by the Txmanager contract.
-type TxmanagerOnContractCallIterator struct {
-	Event *TxmanagerOnContractCall // Event containing the contract specifics and raw log
+// TxmanagerOnAbortIterator is returned from FilterOnAbort and is used to iterate over the raw logs and unpacked data for OnAbort events raised by the Txmanager contract.
+type TxmanagerOnAbortIterator struct {
+	Event *TxmanagerOnAbort // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -590,7 +637,7 @@ type TxmanagerOnContractCallIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *TxmanagerOnContractCallIterator) Next() bool {
+func (it *TxmanagerOnAbortIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -599,7 +646,7 @@ func (it *TxmanagerOnContractCallIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(TxmanagerOnContractCall)
+			it.Event = new(TxmanagerOnAbort)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -614,7 +661,7 @@ func (it *TxmanagerOnContractCallIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(TxmanagerOnContractCall)
+		it.Event = new(TxmanagerOnAbort)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -630,30 +677,28 @@ func (it *TxmanagerOnContractCallIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *TxmanagerOnContractCallIterator) Error() error {
+func (it *TxmanagerOnAbortIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *TxmanagerOnContractCallIterator) Close() error {
+func (it *TxmanagerOnAbortIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// TxmanagerOnContractCall represents a OnContractCall event raised by the Txmanager contract.
-type TxmanagerOnContractCall struct {
+// TxmanagerOnAbort represents a OnAbort event raised by the Txmanager contract.
+type TxmanagerOnAbort struct {
 	TxID    common.Hash
 	TxIndex uint8
-	Success bool
-	Ret     []byte
 	Raw     types.Log // Blockchain specific contextual infos
 }
 
-// FilterOnContractCall is a free log retrieval operation binding the contract event 0x3cf6800c9da1119c1bcca8a173f94e0cd281ab3fae5f1e09ebbb95a64092584f.
+// FilterOnAbort is a free log retrieval operation binding the contract event 0x250bcd3f1f48512b15dbba0fb804f06878f25675cc2381898c392169d814a6f1.
 //
-// Solidity: event OnContractCall(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret)
-func (_Txmanager *TxmanagerFilterer) FilterOnContractCall(opts *bind.FilterOpts, txID [][]byte, txIndex []uint8, success []bool) (*TxmanagerOnContractCallIterator, error) {
+// Solidity: event OnAbort(bytes indexed txID, uint8 indexed txIndex)
+func (_Txmanager *TxmanagerFilterer) FilterOnAbort(opts *bind.FilterOpts, txID [][]byte, txIndex []uint8) (*TxmanagerOnAbortIterator, error) {
 
 	var txIDRule []interface{}
 	for _, txIDItem := range txID {
@@ -663,22 +708,18 @@ func (_Txmanager *TxmanagerFilterer) FilterOnContractCall(opts *bind.FilterOpts,
 	for _, txIndexItem := range txIndex {
 		txIndexRule = append(txIndexRule, txIndexItem)
 	}
-	var successRule []interface{}
-	for _, successItem := range success {
-		successRule = append(successRule, successItem)
-	}
 
-	logs, sub, err := _Txmanager.contract.FilterLogs(opts, "OnContractCall", txIDRule, txIndexRule, successRule)
+	logs, sub, err := _Txmanager.contract.FilterLogs(opts, "OnAbort", txIDRule, txIndexRule)
 	if err != nil {
 		return nil, err
 	}
-	return &TxmanagerOnContractCallIterator{contract: _Txmanager.contract, event: "OnContractCall", logs: logs, sub: sub}, nil
+	return &TxmanagerOnAbortIterator{contract: _Txmanager.contract, event: "OnAbort", logs: logs, sub: sub}, nil
 }
 
-// WatchOnContractCall is a free log subscription operation binding the contract event 0x3cf6800c9da1119c1bcca8a173f94e0cd281ab3fae5f1e09ebbb95a64092584f.
+// WatchOnAbort is a free log subscription operation binding the contract event 0x250bcd3f1f48512b15dbba0fb804f06878f25675cc2381898c392169d814a6f1.
 //
-// Solidity: event OnContractCall(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret)
-func (_Txmanager *TxmanagerFilterer) WatchOnContractCall(opts *bind.WatchOpts, sink chan<- *TxmanagerOnContractCall, txID [][]byte, txIndex []uint8, success []bool) (event.Subscription, error) {
+// Solidity: event OnAbort(bytes indexed txID, uint8 indexed txIndex)
+func (_Txmanager *TxmanagerFilterer) WatchOnAbort(opts *bind.WatchOpts, sink chan<- *TxmanagerOnAbort, txID [][]byte, txIndex []uint8) (event.Subscription, error) {
 
 	var txIDRule []interface{}
 	for _, txIDItem := range txID {
@@ -688,12 +729,8 @@ func (_Txmanager *TxmanagerFilterer) WatchOnContractCall(opts *bind.WatchOpts, s
 	for _, txIndexItem := range txIndex {
 		txIndexRule = append(txIndexRule, txIndexItem)
 	}
-	var successRule []interface{}
-	for _, successItem := range success {
-		successRule = append(successRule, successItem)
-	}
 
-	logs, sub, err := _Txmanager.contract.WatchLogs(opts, "OnContractCall", txIDRule, txIndexRule, successRule)
+	logs, sub, err := _Txmanager.contract.WatchLogs(opts, "OnAbort", txIDRule, txIndexRule)
 	if err != nil {
 		return nil, err
 	}
@@ -703,8 +740,8 @@ func (_Txmanager *TxmanagerFilterer) WatchOnContractCall(opts *bind.WatchOpts, s
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(TxmanagerOnContractCall)
-				if err := _Txmanager.contract.UnpackLog(event, "OnContractCall", log); err != nil {
+				event := new(TxmanagerOnAbort)
+				if err := _Txmanager.contract.UnpackLog(event, "OnAbort", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -725,12 +762,627 @@ func (_Txmanager *TxmanagerFilterer) WatchOnContractCall(opts *bind.WatchOpts, s
 	}), nil
 }
 
-// ParseOnContractCall is a log parse operation binding the contract event 0x3cf6800c9da1119c1bcca8a173f94e0cd281ab3fae5f1e09ebbb95a64092584f.
+// ParseOnAbort is a log parse operation binding the contract event 0x250bcd3f1f48512b15dbba0fb804f06878f25675cc2381898c392169d814a6f1.
 //
-// Solidity: event OnContractCall(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret)
-func (_Txmanager *TxmanagerFilterer) ParseOnContractCall(log types.Log) (*TxmanagerOnContractCall, error) {
-	event := new(TxmanagerOnContractCall)
-	if err := _Txmanager.contract.UnpackLog(event, "OnContractCall", log); err != nil {
+// Solidity: event OnAbort(bytes indexed txID, uint8 indexed txIndex)
+func (_Txmanager *TxmanagerFilterer) ParseOnAbort(log types.Log) (*TxmanagerOnAbort, error) {
+	event := new(TxmanagerOnAbort)
+	if err := _Txmanager.contract.UnpackLog(event, "OnAbort", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TxmanagerOnCommitIterator is returned from FilterOnCommit and is used to iterate over the raw logs and unpacked data for OnCommit events raised by the Txmanager contract.
+type TxmanagerOnCommitIterator struct {
+	Event *TxmanagerOnCommit // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TxmanagerOnCommitIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TxmanagerOnCommit)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TxmanagerOnCommit)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TxmanagerOnCommitIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TxmanagerOnCommitIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TxmanagerOnCommit represents a OnCommit event raised by the Txmanager contract.
+type TxmanagerOnCommit struct {
+	TxID    common.Hash
+	TxIndex uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterOnCommit is a free log retrieval operation binding the contract event 0x7aaf0b63467fb40eac34c045248842f31e4e1edff7f0dd939f7ddeeddd83adc0.
+//
+// Solidity: event OnCommit(bytes indexed txID, uint8 indexed txIndex)
+func (_Txmanager *TxmanagerFilterer) FilterOnCommit(opts *bind.FilterOpts, txID [][]byte, txIndex []uint8) (*TxmanagerOnCommitIterator, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+
+	logs, sub, err := _Txmanager.contract.FilterLogs(opts, "OnCommit", txIDRule, txIndexRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TxmanagerOnCommitIterator{contract: _Txmanager.contract, event: "OnCommit", logs: logs, sub: sub}, nil
+}
+
+// WatchOnCommit is a free log subscription operation binding the contract event 0x7aaf0b63467fb40eac34c045248842f31e4e1edff7f0dd939f7ddeeddd83adc0.
+//
+// Solidity: event OnCommit(bytes indexed txID, uint8 indexed txIndex)
+func (_Txmanager *TxmanagerFilterer) WatchOnCommit(opts *bind.WatchOpts, sink chan<- *TxmanagerOnCommit, txID [][]byte, txIndex []uint8) (event.Subscription, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+
+	logs, sub, err := _Txmanager.contract.WatchLogs(opts, "OnCommit", txIDRule, txIndexRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TxmanagerOnCommit)
+				if err := _Txmanager.contract.UnpackLog(event, "OnCommit", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOnCommit is a log parse operation binding the contract event 0x7aaf0b63467fb40eac34c045248842f31e4e1edff7f0dd939f7ddeeddd83adc0.
+//
+// Solidity: event OnCommit(bytes indexed txID, uint8 indexed txIndex)
+func (_Txmanager *TxmanagerFilterer) ParseOnCommit(log types.Log) (*TxmanagerOnCommit, error) {
+	event := new(TxmanagerOnCommit)
+	if err := _Txmanager.contract.UnpackLog(event, "OnCommit", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TxmanagerOnContractCommitImmediatelyIterator is returned from FilterOnContractCommitImmediately and is used to iterate over the raw logs and unpacked data for OnContractCommitImmediately events raised by the Txmanager contract.
+type TxmanagerOnContractCommitImmediatelyIterator struct {
+	Event *TxmanagerOnContractCommitImmediately // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TxmanagerOnContractCommitImmediatelyIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TxmanagerOnContractCommitImmediately)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TxmanagerOnContractCommitImmediately)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TxmanagerOnContractCommitImmediatelyIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TxmanagerOnContractCommitImmediatelyIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TxmanagerOnContractCommitImmediately represents a OnContractCommitImmediately event raised by the Txmanager contract.
+type TxmanagerOnContractCommitImmediately struct {
+	TxID    common.Hash
+	TxIndex uint8
+	Success bool
+	Ret     []byte
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterOnContractCommitImmediately is a free log retrieval operation binding the contract event 0x7da7723d423258c97d02fba73c0951597dc48566af572d5cb8e2698c22102e61.
+//
+// Solidity: event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret)
+func (_Txmanager *TxmanagerFilterer) FilterOnContractCommitImmediately(opts *bind.FilterOpts, txID [][]byte, txIndex []uint8, success []bool) (*TxmanagerOnContractCommitImmediatelyIterator, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+	var successRule []interface{}
+	for _, successItem := range success {
+		successRule = append(successRule, successItem)
+	}
+
+	logs, sub, err := _Txmanager.contract.FilterLogs(opts, "OnContractCommitImmediately", txIDRule, txIndexRule, successRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TxmanagerOnContractCommitImmediatelyIterator{contract: _Txmanager.contract, event: "OnContractCommitImmediately", logs: logs, sub: sub}, nil
+}
+
+// WatchOnContractCommitImmediately is a free log subscription operation binding the contract event 0x7da7723d423258c97d02fba73c0951597dc48566af572d5cb8e2698c22102e61.
+//
+// Solidity: event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret)
+func (_Txmanager *TxmanagerFilterer) WatchOnContractCommitImmediately(opts *bind.WatchOpts, sink chan<- *TxmanagerOnContractCommitImmediately, txID [][]byte, txIndex []uint8, success []bool) (event.Subscription, error) {
+
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+	var txIndexRule []interface{}
+	for _, txIndexItem := range txIndex {
+		txIndexRule = append(txIndexRule, txIndexItem)
+	}
+	var successRule []interface{}
+	for _, successItem := range success {
+		successRule = append(successRule, successItem)
+	}
+
+	logs, sub, err := _Txmanager.contract.WatchLogs(opts, "OnContractCommitImmediately", txIDRule, txIndexRule, successRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TxmanagerOnContractCommitImmediately)
+				if err := _Txmanager.contract.UnpackLog(event, "OnContractCommitImmediately", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOnContractCommitImmediately is a log parse operation binding the contract event 0x7da7723d423258c97d02fba73c0951597dc48566af572d5cb8e2698c22102e61.
+//
+// Solidity: event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret)
+func (_Txmanager *TxmanagerFilterer) ParseOnContractCommitImmediately(log types.Log) (*TxmanagerOnContractCommitImmediately, error) {
+	event := new(TxmanagerOnContractCommitImmediately)
+	if err := _Txmanager.contract.UnpackLog(event, "OnContractCommitImmediately", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TxmanagerTxInitiatedIterator is returned from FilterTxInitiated and is used to iterate over the raw logs and unpacked data for TxInitiated events raised by the Txmanager contract.
+type TxmanagerTxInitiatedIterator struct {
+	Event *TxmanagerTxInitiated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TxmanagerTxInitiatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TxmanagerTxInitiated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TxmanagerTxInitiated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TxmanagerTxInitiatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TxmanagerTxInitiatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TxmanagerTxInitiated represents a TxInitiated event raised by the Txmanager contract.
+type TxmanagerTxInitiated struct {
+	TxID     []byte
+	Proposer common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterTxInitiated is a free log retrieval operation binding the contract event 0x0bc2e2a7d294f6ab6e77997aaed7a9ef6e8265de18f7085a5453bf8638b8af0e.
+//
+// Solidity: event TxInitiated(bytes txID, address indexed proposer)
+func (_Txmanager *TxmanagerFilterer) FilterTxInitiated(opts *bind.FilterOpts, proposer []common.Address) (*TxmanagerTxInitiatedIterator, error) {
+
+	var proposerRule []interface{}
+	for _, proposerItem := range proposer {
+		proposerRule = append(proposerRule, proposerItem)
+	}
+
+	logs, sub, err := _Txmanager.contract.FilterLogs(opts, "TxInitiated", proposerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TxmanagerTxInitiatedIterator{contract: _Txmanager.contract, event: "TxInitiated", logs: logs, sub: sub}, nil
+}
+
+// WatchTxInitiated is a free log subscription operation binding the contract event 0x0bc2e2a7d294f6ab6e77997aaed7a9ef6e8265de18f7085a5453bf8638b8af0e.
+//
+// Solidity: event TxInitiated(bytes txID, address indexed proposer)
+func (_Txmanager *TxmanagerFilterer) WatchTxInitiated(opts *bind.WatchOpts, sink chan<- *TxmanagerTxInitiated, proposer []common.Address) (event.Subscription, error) {
+
+	var proposerRule []interface{}
+	for _, proposerItem := range proposer {
+		proposerRule = append(proposerRule, proposerItem)
+	}
+
+	logs, sub, err := _Txmanager.contract.WatchLogs(opts, "TxInitiated", proposerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TxmanagerTxInitiated)
+				if err := _Txmanager.contract.UnpackLog(event, "TxInitiated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTxInitiated is a log parse operation binding the contract event 0x0bc2e2a7d294f6ab6e77997aaed7a9ef6e8265de18f7085a5453bf8638b8af0e.
+//
+// Solidity: event TxInitiated(bytes txID, address indexed proposer)
+func (_Txmanager *TxmanagerFilterer) ParseTxInitiated(log types.Log) (*TxmanagerTxInitiated, error) {
+	event := new(TxmanagerTxInitiated)
+	if err := _Txmanager.contract.UnpackLog(event, "TxInitiated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TxmanagerTxSignedIterator is returned from FilterTxSigned and is used to iterate over the raw logs and unpacked data for TxSigned events raised by the Txmanager contract.
+type TxmanagerTxSignedIterator struct {
+	Event *TxmanagerTxSigned // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TxmanagerTxSignedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TxmanagerTxSigned)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TxmanagerTxSigned)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TxmanagerTxSignedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TxmanagerTxSignedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TxmanagerTxSigned represents a TxSigned event raised by the Txmanager contract.
+type TxmanagerTxSigned struct {
+	Signer common.Address
+	TxID   [32]byte
+	Method uint8
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterTxSigned is a free log retrieval operation binding the contract event 0x30c2a521823a6b9bc4f65ec80485542760a5639a135db9e69f36d257d9c3a716.
+//
+// Solidity: event TxSigned(address indexed signer, bytes32 indexed txID, uint8 method)
+func (_Txmanager *TxmanagerFilterer) FilterTxSigned(opts *bind.FilterOpts, signer []common.Address, txID [][32]byte) (*TxmanagerTxSignedIterator, error) {
+
+	var signerRule []interface{}
+	for _, signerItem := range signer {
+		signerRule = append(signerRule, signerItem)
+	}
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+
+	logs, sub, err := _Txmanager.contract.FilterLogs(opts, "TxSigned", signerRule, txIDRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TxmanagerTxSignedIterator{contract: _Txmanager.contract, event: "TxSigned", logs: logs, sub: sub}, nil
+}
+
+// WatchTxSigned is a free log subscription operation binding the contract event 0x30c2a521823a6b9bc4f65ec80485542760a5639a135db9e69f36d257d9c3a716.
+//
+// Solidity: event TxSigned(address indexed signer, bytes32 indexed txID, uint8 method)
+func (_Txmanager *TxmanagerFilterer) WatchTxSigned(opts *bind.WatchOpts, sink chan<- *TxmanagerTxSigned, signer []common.Address, txID [][32]byte) (event.Subscription, error) {
+
+	var signerRule []interface{}
+	for _, signerItem := range signer {
+		signerRule = append(signerRule, signerItem)
+	}
+	var txIDRule []interface{}
+	for _, txIDItem := range txID {
+		txIDRule = append(txIDRule, txIDItem)
+	}
+
+	logs, sub, err := _Txmanager.contract.WatchLogs(opts, "TxSigned", signerRule, txIDRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TxmanagerTxSigned)
+				if err := _Txmanager.contract.UnpackLog(event, "TxSigned", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTxSigned is a log parse operation binding the contract event 0x30c2a521823a6b9bc4f65ec80485542760a5639a135db9e69f36d257d9c3a716.
+//
+// Solidity: event TxSigned(address indexed signer, bytes32 indexed txID, uint8 method)
+func (_Txmanager *TxmanagerFilterer) ParseTxSigned(log types.Log) (*TxmanagerTxSigned, error) {
+	event := new(TxmanagerTxSigned)
+	if err := _Txmanager.contract.UnpackLog(event, "TxSigned", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/pkg/testing/chain_test.go
+++ b/pkg/testing/chain_test.go
@@ -74,8 +74,8 @@ func (chain *Chain) TxSyncIfNoError(ctx context.Context) func(tx *gethtypes.Tran
 	}
 }
 
-func (chain *Chain) findEventOnContractCall(ctx context.Context, txID []byte) (*txmanager.TxmanagerOnContractCall, error) {
-	filter, err := txmanager.NewTxmanagerFilterer(
+func (chain *Chain) findEventOnContractCommitImmediately(ctx context.Context, txID []byte) (*crosssimplemodule.CrosssimplemoduleOnContractCommitImmediately, error) {
+	filter, err := crosssimplemodule.NewCrosssimplemoduleFilterer(
 		chain.ContractConfig.GetCrossSimpleModuleAddress(), chain.ETHClient,
 	)
 	if err != nil {
@@ -84,7 +84,7 @@ func (chain *Chain) findEventOnContractCall(ctx context.Context, txID []byte) (*
 
 	idHash := crypto.Keccak256Hash(txID)
 
-	iter, err := filter.FilterOnContractCall(
+	iter, err := filter.FilterOnContractCommitImmediately(
 		&bind.FilterOpts{Context: ctx},
 		[][]byte{txID}, // txId
 		nil,            // txIndex

--- a/pkg/testing/cross_test.go
+++ b/pkg/testing/cross_test.go
@@ -66,7 +66,7 @@ func (suite *CrossTestSuite) TestRecvPacket() {
 		))
 
 		// 3. check if a fired event matches expected one
-		event, err := suite.chain.findEventOnContractCall(ctx, txID)
+		event, err := suite.chain.findEventOnContractCommitImmediately(ctx, txID)
 		suite.Require().NoError(err)
 		suite.Require().True(event.Success)
 		suite.Require().Equal(event.Ret, successMsg)
@@ -94,7 +94,7 @@ func (suite *CrossTestSuite) TestRecvPacket() {
 		))
 
 		// 3. check if a fired event matches expected one
-		event, err := suite.chain.findEventOnContractCall(ctx, txID)
+		event, err := suite.chain.findEventOnContractCommitImmediately(ctx, txID)
 		suite.Require().NoError(err)
 		suite.Require().False(event.Success)
 		suite.Require().Empty(event.Ret)

--- a/src/core/Authenticator.sol
+++ b/src/core/Authenticator.sol
@@ -5,6 +5,7 @@ import {IAuthenticator} from "./IAuthenticator.sol";
 import {TxAuthManagerBase} from "./TxAuthManagerBase.sol";
 import {TxManagerBase} from "./TxManagerBase.sol";
 import {ICrossError} from "./ICrossError.sol";
+import {ICrossEvent} from "./ICrossEvent.sol";
 
 import {
     AuthType,
@@ -19,7 +20,7 @@ import {
 } from "../proto/cross/core/auth/Auth.sol";
 import {GoogleProtobufAny} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/GoogleProtobufAny.sol";
 
-abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, ICrossError {
+abstract contract Authenticator is IAuthenticator, TxAuthManagerBase, TxManagerBase, ICrossError, ICrossEvent {
     function signTx(MsgSignTx.Data calldata msg_) external override returns (MsgSignTxResponse.Data memory) {
         bytes32 txID = _decodeTxID(msg_.txID);
 

--- a/src/core/IAuthenticator.sol
+++ b/src/core/IAuthenticator.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.20;
 
 import {
-    AuthType,
     MsgSignTx,
     MsgSignTxResponse,
     MsgExtSignTx,
@@ -12,8 +11,6 @@ import {
 } from "../proto/cross/core/auth/Auth.sol";
 
 interface IAuthenticator {
-    event TxSigned(address indexed signer, bytes32 indexed txID, AuthType.AuthMode method);
-
     function signTx(MsgSignTx.Data calldata msg_) external returns (MsgSignTxResponse.Data memory);
 
     // IBC signing is not supported

--- a/src/core/ICrossEvent.sol
+++ b/src/core/ICrossEvent.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import {AuthType} from "../proto/cross/core/auth/Auth.sol";
+
+interface ICrossEvent {
+    event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret);
+    event OnCommit(bytes indexed txID, uint8 indexed txIndex);
+    event OnAbort(bytes indexed txID, uint8 indexed txIndex);
+    event TxSigned(address indexed signer, bytes32 indexed txID, AuthType.AuthMode method);
+    event TxInitiated(bytes txID, address indexed proposer);
+}

--- a/src/core/IInitiator.sol
+++ b/src/core/IInitiator.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.20;
 import {MsgInitiateTx, MsgInitiateTxResponse, QuerySelfXCCResponse} from "../proto/cross/core/initiator/Initiator.sol";
 
 interface IInitiator {
-    event TxInitiated(bytes txID, address indexed proposer);
-
     function initiateTx(MsgInitiateTx.Data calldata msg_) external returns (MsgInitiateTxResponse.Data memory resp);
 
     function selfXCC() external view returns (QuerySelfXCCResponse.Data memory resp);

--- a/src/core/Initiator.sol
+++ b/src/core/Initiator.sol
@@ -5,6 +5,7 @@ import {IInitiator} from "./IInitiator.sol";
 import {TxAuthManagerBase} from "./TxAuthManagerBase.sol";
 import {TxManagerBase} from "./TxManagerBase.sol";
 import {ICrossError} from "./ICrossError.sol";
+import {ICrossEvent} from "./ICrossEvent.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 import {MsgInitiateTx, MsgInitiateTxResponse, QuerySelfXCCResponse} from "../proto/cross/core/initiator/Initiator.sol";
@@ -14,7 +15,7 @@ import {ChannelInfo} from "../proto/cross/core/xcc/XCC.sol";
 
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-abstract contract Initiator is IInitiator, TxAuthManagerBase, TxManagerBase, ReentrancyGuard, ICrossError {
+abstract contract Initiator is IInitiator, TxAuthManagerBase, TxManagerBase, ReentrancyGuard, ICrossError, ICrossEvent {
     bytes32 public immutable CHAIN_ID_HASH;
 
     constructor() {

--- a/src/core/TxAtomicSimple.sol
+++ b/src/core/TxAtomicSimple.sol
@@ -47,7 +47,9 @@ abstract contract TxAtomicSimple is
     uint8 private constant TX_INDEX_COORDINATOR = 0;
     uint8 private constant TX_INDEX_PARTICIPANT = 1;
 
-    event OnContractCall(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret);
+    event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret);
+    event OnCommit(bytes indexed txID, uint8 indexed txIndex);
+    event OnAbort(bytes indexed txID, uint8 indexed txIndex);
 
     function _runTx(bytes32 txID, MsgInitiateTx.Data storage msg_) internal virtual override {
         if (msg_.commit_protocol == Tx.CommitProtocol.COMMIT_PROTOCOL_SIMPLE) {
@@ -262,11 +264,11 @@ abstract contract TxAtomicSimple is
         ) returns (bytes memory ret) {
             ack.status = PacketAcknowledgementCall.CommitStatus.COMMIT_STATUS_OK;
             // slither-disable-next-line reentrancy-events
-            emit OnContractCall(pdc.tx_id, TX_INDEX_PARTICIPANT, true, ret);
+            emit OnContractCommitImmediately(pdc.tx_id, TX_INDEX_PARTICIPANT, true, ret);
         } catch (bytes memory) {
             ack.status = PacketAcknowledgementCall.CommitStatus.COMMIT_STATUS_FAILED;
             // slither-disable-next-line reentrancy-events
-            emit OnContractCall(pdc.tx_id, TX_INDEX_PARTICIPANT, false, new bytes(0));
+            emit OnContractCommitImmediately(pdc.tx_id, TX_INDEX_PARTICIPANT, false, new bytes(0));
         }
 
         return packPacketAcknowledgementCall(ack);
@@ -428,10 +430,14 @@ abstract contract TxAtomicSimple is
             // Commit
             module.onCommit(ctx);
             txState.status = ContractTransactionState.ContractTransactionStatus.CONTRACT_TRANSACTION_STATUS_COMMIT;
+            // slither-disable-next-line reentrancy-events
+            emit OnCommit(abi.encodePacked(txID), TX_INDEX_COORDINATOR);
         } else {
             // Abort
             module.onAbort(ctx);
             txState.status = ContractTransactionState.ContractTransactionStatus.CONTRACT_TRANSACTION_STATUS_ABORT;
+            // slither-disable-next-line reentrancy-events
+            emit OnAbort(abi.encodePacked(txID), TX_INDEX_COORDINATOR);
         }
     }
 

--- a/src/core/TxAtomicSimple.sol
+++ b/src/core/TxAtomicSimple.sol
@@ -12,6 +12,7 @@ import "./IContractModule.sol";
 import "./IBCKeeper.sol";
 import {TxRunnerBase} from "./TxRunnerBase.sol";
 import {ICrossError} from "./ICrossError.sol";
+import {ICrossEvent} from "./ICrossEvent.sol";
 
 import {
     PacketData,
@@ -37,7 +38,8 @@ abstract contract TxAtomicSimple is
     PacketHandler,
     TxRunnerBase,
     ContractRegistry,
-    ICrossError
+    ICrossError,
+    ICrossEvent
 {
     function __initTxAtomicSimple(IIBCHandler handler_, IContractModule module) internal virtual onlyInitializing {
         __initIBCKeeper(handler_);
@@ -46,10 +48,6 @@ abstract contract TxAtomicSimple is
 
     uint8 private constant TX_INDEX_COORDINATOR = 0;
     uint8 private constant TX_INDEX_PARTICIPANT = 1;
-
-    event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret);
-    event OnCommit(bytes indexed txID, uint8 indexed txIndex);
-    event OnAbort(bytes indexed txID, uint8 indexed txIndex);
 
     function _runTx(bytes32 txID, MsgInitiateTx.Data storage msg_) internal virtual override {
         if (msg_.commit_protocol == Tx.CommitProtocol.COMMIT_PROTOCOL_SIMPLE) {

--- a/test/Authenticator.t.sol
+++ b/test/Authenticator.t.sol
@@ -8,8 +8,8 @@ import {TxManagerBase} from "../src/core/TxManagerBase.sol";
 import {TxAuthManagerBase} from "../src/core/TxAuthManagerBase.sol";
 
 import {MsgInitiateTx} from "../src/proto/cross/core/initiator/Initiator.sol";
-import {IAuthenticator} from "../src/core/IAuthenticator.sol";
 import {ICrossError} from "../src/core/ICrossError.sol";
+import {ICrossEvent} from "../src/core/ICrossEvent.sol";
 import {
     Account as AuthAccount,
     AuthType,
@@ -156,7 +156,7 @@ contract AuthenticatorHarness is Authenticator, MockTxAuthManager, MockTxManager
     }
 }
 
-contract AuthenticatorTest is Test, ICrossError {
+contract AuthenticatorTest is Test, ICrossError, ICrossEvent {
     AuthenticatorHarness private harness;
     MsgSignTx.Data private baseMsg;
     bytes32 private txID;
@@ -213,7 +213,7 @@ contract AuthenticatorTest is Test, ICrossError {
         harness.setSignReturns(true);
 
         vm.expectEmit(true, true, false, true, address(harness));
-        emit IAuthenticator.TxSigned(address(this), txID, AuthType.AuthMode.AUTH_MODE_LOCAL);
+        emit TxSigned(address(this), txID, AuthType.AuthMode.AUTH_MODE_LOCAL);
 
         MsgSignTxResponse.Data memory resp = harness.signTx(baseMsg);
 
@@ -260,7 +260,7 @@ contract AuthenticatorTest is Test, ICrossError {
     function test_extSignTx_SucceedsAsPending() public {
         harness.setSignReturns(false);
         vm.expectEmit(address(harness));
-        emit IAuthenticator.TxSigned(address(this), extTxID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+        emit TxSigned(address(this), extTxID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);
 
@@ -273,7 +273,7 @@ contract AuthenticatorTest is Test, ICrossError {
         harness.setSignReturns(true);
 
         vm.expectEmit(address(harness));
-        emit IAuthenticator.TxSigned(address(this), extTxID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
+        emit TxSigned(address(this), extTxID, AuthType.AuthMode.AUTH_MODE_EXTENSION);
 
         MsgExtSignTxResponse.Data memory resp = harness.extSignTx(extMsg);
 

--- a/test/Initiator.t.sol
+++ b/test/Initiator.t.sol
@@ -6,7 +6,7 @@ import "forge-std/src/Test.sol";
 import "../src/core/Initiator.sol";
 import {TxManagerBase} from "../src/core/TxManagerBase.sol";
 import {TxAuthManagerBase} from "../src/core/TxAuthManagerBase.sol";
-import {IInitiator} from "../src/core/IInitiator.sol";
+import {ICrossEvent} from "../src/core/ICrossEvent.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 import {
@@ -109,7 +109,7 @@ contract InitiatorHarness is Initiator, MockTxAuthManager, MockTxManager {
     }
 }
 
-contract InitiatorTest is Test {
+contract InitiatorTest is Test, ICrossEvent {
     InitiatorHarness private harness;
     MsgInitiateTx.Data private baseMsg;
     AuthAccount.Data private signerA;
@@ -166,7 +166,7 @@ contract InitiatorTest is Test {
         harness.setSignReturns(false);
 
         vm.expectEmit(true, false, false, true, address(harness));
-        emit IInitiator.TxInitiated(abi.encodePacked(txIDHash), address(this));
+        emit TxInitiated(abi.encodePacked(txIDHash), address(this));
 
         MsgInitiateTxResponse.Data memory resp = harness.initiateTx(baseMsg);
 
@@ -188,7 +188,7 @@ contract InitiatorTest is Test {
         harness.setSignReturns(true);
 
         vm.expectEmit(true, false, false, true, address(harness));
-        emit IInitiator.TxInitiated(abi.encodePacked(txIDHash), address(this));
+        emit TxInitiated(abi.encodePacked(txIDHash), address(this));
 
         MsgInitiateTxResponse.Data memory resp = harness.initiateTx(baseMsg);
 

--- a/test/TxAtomicSimple.t.sol
+++ b/test/TxAtomicSimple.t.sol
@@ -551,7 +551,7 @@ contract TxAtomicSimpleTest is Test, ICrossError {
 
     // --- _handleAcknowledgement Tests ---
 
-    function test_handleAck_CommitSuccess() public {
+    function test_handleAck_Success() public {
         _setupCoordStateForAck(CoordinatorState.CoordinatorPhase.COORDINATOR_PHASE_PREPARE);
 
         Packet memory p = _createPacket(TX_ID, "", "port-1", "channel-1");
@@ -570,7 +570,7 @@ contract TxAtomicSimpleTest is Test, ICrossError {
         assertEq(mockModule.onAbortCallCount(), 0, "onAbort should not be called");
     }
 
-    function test_handleAck_CommitFailure() public {
+    function test_handleAck_Failure() public {
         _setupCoordStateForAck(CoordinatorState.CoordinatorPhase.COORDINATOR_PHASE_PREPARE);
 
         Packet memory p = _createPacket(TX_ID, "", "port-1", "channel-1");

--- a/test/TxAtomicSimple.t.sol
+++ b/test/TxAtomicSimple.t.sol
@@ -204,7 +204,9 @@ contract TxAtomicSimpleTest is Test, ICrossError {
 
     bytes32 private constant TX_ID = keccak256("test-tx");
 
-    event OnContractCall(bytes indexed txId, uint8 indexed txIndex, bool indexed success, bytes ret);
+    event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret);
+    event OnCommit(bytes indexed txID, uint8 indexed txIndex);
+    event OnAbort(bytes indexed txID, uint8 indexed txIndex);
 
     function setUp() public {
         mockHandler = new MockIBCHandler();
@@ -336,7 +338,7 @@ contract TxAtomicSimpleTest is Test, ICrossError {
         Packet memory packet = _createPacket(TX_ID, hex"c0ffee", "port-1", "channel-1");
 
         vm.expectEmit(address(harness));
-        emit OnContractCall(abi.encodePacked(TX_ID), 1, true, hex"01");
+        emit OnContractCommitImmediately(abi.encodePacked(TX_ID), 1, true, hex"01");
 
         bytes memory ack = harness.exposed_handlePacket(packet);
 
@@ -356,7 +358,7 @@ contract TxAtomicSimpleTest is Test, ICrossError {
         Packet memory packet = _createPacket(TX_ID, hex"00", "port-1", "channel-1");
 
         vm.expectEmit(address(harness));
-        emit OnContractCall(abi.encodePacked(TX_ID), 1, false, "");
+        emit OnContractCommitImmediately(abi.encodePacked(TX_ID), 1, false, "");
 
         bytes memory ack = harness.exposed_handlePacket(packet);
 
@@ -549,11 +551,14 @@ contract TxAtomicSimpleTest is Test, ICrossError {
 
     // --- _handleAcknowledgement Tests ---
 
-    function test_handleAck_Commit_Success() public {
+    function test_handleAck_CommitSuccess() public {
         _setupCoordStateForAck(CoordinatorState.CoordinatorPhase.COORDINATOR_PHASE_PREPARE);
 
         Packet memory p = _createPacket(TX_ID, "", "port-1", "channel-1");
         bytes memory ack = _createAck(PacketAcknowledgementCall.CommitStatus.COMMIT_STATUS_OK);
+
+        vm.expectEmit(address(harness));
+        emit OnCommit(abi.encodePacked(TX_ID), 0);
 
         harness.exposed_handleAcknowledgement(p, ack);
 
@@ -565,11 +570,14 @@ contract TxAtomicSimpleTest is Test, ICrossError {
         assertEq(mockModule.onAbortCallCount(), 0, "onAbort should not be called");
     }
 
-    function test_handleAck_Abort_Failure() public {
+    function test_handleAck_CommitFailure() public {
         _setupCoordStateForAck(CoordinatorState.CoordinatorPhase.COORDINATOR_PHASE_PREPARE);
 
         Packet memory p = _createPacket(TX_ID, "", "port-1", "channel-1");
         bytes memory ack = _createAck(PacketAcknowledgementCall.CommitStatus.COMMIT_STATUS_FAILED);
+
+        vm.expectEmit(address(harness));
+        emit OnAbort(abi.encodePacked(TX_ID), 0);
 
         harness.exposed_handleAcknowledgement(p, ack);
 

--- a/test/TxAtomicSimple.t.sol
+++ b/test/TxAtomicSimple.t.sol
@@ -7,6 +7,7 @@ import "forge-std/src/Test.sol";
 import "../src/core/TxAtomicSimple.sol";
 import "../src/core/IContractModule.sol";
 import "../src/core/ICrossError.sol";
+import "../src/core/ICrossEvent.sol";
 import {Packet} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/04-channel/IIBCChannel.sol";
 import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 import {Height} from "@hyperledger-labs/yui-ibc-solidity/contracts/proto/Client.sol";
@@ -197,16 +198,12 @@ contract TxAtomicSimpleHarness is TxAtomicSimple, MockContractRegistry {
     }
 }
 
-contract TxAtomicSimpleTest is Test, ICrossError {
+contract TxAtomicSimpleTest is Test, ICrossError, ICrossEvent {
     TxAtomicSimpleHarness private harness;
     MockIBCHandler private mockHandler;
     MockModule private mockModule;
 
     bytes32 private constant TX_ID = keccak256("test-tx");
-
-    event OnContractCommitImmediately(bytes indexed txID, uint8 indexed txIndex, bool indexed success, bytes ret);
-    event OnCommit(bytes indexed txID, uint8 indexed txIndex);
-    event OnAbort(bytes indexed txID, uint8 indexed txIndex);
 
     function setUp() public {
         mockHandler = new MockIBCHandler();


### PR DESCRIPTION
- Aggregated all events into `ICrossEvent`.
- Renamed `OnContractCommit` to `OnContractCommitImmediately`.
- Added `OnCommit` and `OnAbort` events.