### PR TITLE
feat: enhance _accountKey function to handle AUTH_MODE_EXTENSION case

### DIFF
--- a/src/core/TxAuthManager.sol
+++ b/src/core/TxAuthManager.sol
@@ -149,6 +149,13 @@ contract TxAuthManager is Initializable, TxAuthManagerBase, CrossStore, ITxAuthM
     }
 
     function _accountKey(Account.Data memory a) internal pure returns (bytes32) {
+        if (a.auth_type.mode == AuthType.AuthMode.AUTH_MODE_EXTENSION) {
+            return keccak256(abi.encode(
+                a.id, 
+                a.auth_type.mode, 
+                a.auth_type.option.type_url
+            ));
+        }
         return keccak256(abi.encode(a.id, a.auth_type));
     }
 }

--- a/test/TxAuthManager.t.sol
+++ b/test/TxAuthManager.t.sol
@@ -389,6 +389,27 @@ contract TxAuthManagerTest is Test, ICrossError {
         assertEq(keyA, keyACopy, "Identical accounts should produce the same key");
     }
 
+    function test_accountKey_ExtensionModeIgnoresOptionValue() public {
+        bytes memory id = bytes("user1");
+        string memory typeUrl = URL_VALID;
+
+        GoogleProtobufAny.Data memory optionA = GoogleProtobufAny.Data({type_url: typeUrl, value: hex"aaaa"});
+        GoogleProtobufAny.Data memory optionB = GoogleProtobufAny.Data({type_url: typeUrl, value: hex"bbbb"});
+
+        AuthAccount.Data memory accA = AuthAccount.Data({
+            id: id, auth_type: AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_EXTENSION, option: optionA})
+        });
+
+        AuthAccount.Data memory accB = AuthAccount.Data({
+            id: id, auth_type: AuthType.Data({mode: AuthType.AuthMode.AUTH_MODE_EXTENSION, option: optionB})
+        });
+
+        bytes32 keyA = harness.exposed_accountKey(accA);
+        bytes32 keyB = harness.exposed_accountKey(accB);
+
+        assertEq(keyA, keyB, "Extension mode should ignore option.value in accountKey generation");
+    }
+
     function test_setStateFromRemainingList_HandlesDuplicatesAndReturnsRemains() public {
         AuthAccount.Data[] memory signers = new AuthAccount.Data[](3);
         signers[0] = signerA;


### PR DESCRIPTION
- Issue: _sign() fails during extSignTx.
- Cause: A bug caused distinct hash values to be generated for two Account.Data instances that should be treated as identical. This has been fixed.

```json
{
  "Id": "AHMVQM1gYJkda5xXzilZmNm8L6s=",
  "AuthType": {
    "Mode": 3,
    "Option": {
      "TypeUrl": "/verifier.sample.extension",
      "Value": ""
    }
  }
}
```

```json
{
  "Id": "AHMVQM1gYJkda5xXzilZmNm8L6s=",
  "AuthType": {
    "Mode": 3,
    "Option": {
      "TypeUrl": "/verifier.sample.extension",
      "Value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEDCUmZoBBegKy+RoE0WqlxsOxiRVr+pMkiz8ZhTeZjdUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBMKEs65z9pO27V0xKSJtC7fZApRXsLaWjZCJcoLBvf3JidQvNxtifN7FKFFeiocKtOsTXVvgm1qwRLUst0CGrlhwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
    }
  }
}
```