### PR TITLE
fix: use relative imports in CrossStore.sol and ICoordinator.sol

### DIFF
--- a/src/core/CrossStore.sol
+++ b/src/core/CrossStore.sol
@@ -5,7 +5,7 @@ import {IAuthExtensionVerifier} from "./IAuthExtensionVerifier.sol";
 import {IContractModule} from "./IContractModule.sol";
 import {MsgInitiateTx, MsgInitiateTxResponse} from "../proto/cross/core/initiator/Initiator.sol";
 import {Account} from "../proto/cross/core/auth/Auth.sol";
-import {CoordinatorState, ContractTransactionState} from "src/proto/cross/core/atomic/simple/AtomicSimple.sol";
+import {CoordinatorState, ContractTransactionState} from "../proto/cross/core/atomic/simple/AtomicSimple.sol";
 import {IIBCHandler} from "@hyperledger-labs/yui-ibc-solidity/contracts/core/25-handler/IIBCHandler.sol";
 
 abstract contract CrossStore {

--- a/src/core/ICoordinator.sol
+++ b/src/core/ICoordinator.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import {
     QueryCoordinatorStateRequest,
     QueryCoordinatorStateResponse
-} from "src/proto/cross/core/atomic/simple/AtomicSimple.sol";
+} from "../proto/cross/core/atomic/simple/AtomicSimple.sol";
 
 interface ICoordinator {
     function coordinatorState(QueryCoordinatorStateRequest.Data calldata req)


### PR DESCRIPTION
## Description
Replaced absolute imports (`src/proto/...`) with relative paths in `CrossStore.sol` and `ICoordinator.sol`.

## Motivation
Using absolute paths causes build errors when this repository is installed as a dependency, as the compiler attempts to resolve `src` from the consumer's project root. This fix eliminates the need for users to configure manual remappings.